### PR TITLE
Don’t expand `any` expressions with nested or/in functions when all function arguments are subvariable ids

### DIFF
--- a/scrunch/tests/test_expressions.py
+++ b/scrunch/tests/test_expressions.py
@@ -1482,6 +1482,39 @@ class TestExpressionProcessing(TestCase):
             ]
         }
 
+    def test_has_any_processing(self):
+        expr = 'a.has_any(["1", "2"])'
+        parsed = parse_expr(expr)
+        assert parsed == {
+            'function': 'any',
+            'args': [{'variable': 'a'}, {'value': ['1', '2']}],
+        }
+        urls_map = {
+            'a': {'id': 'url/a', 'type': 'multiple_response', 'subvariables': ['1', '2']},
+            '1': {'id': 'url/1', 'type': 'categorical', 'is_subvar': True},
+            '2': {'id': 'url/2', 'type': 'categorical', 'is_subvar': True},
+        }
+        ds = mock.MagicMock()
+        ds.self = '/dataset/'
+        gdv = lambda ds: urls_map
+        with mock.patch('scrunch.expressions.get_dataset_variables', gdv):
+            processed = process_expr(parsed, ds)
+
+        assert processed == {
+            'function': 'any',
+            'args': [
+                {
+                    'variable': '/dataset/variables/url/a/'
+                },
+                {
+                    'value': [
+                        '/dataset/variables/url/a/subvariables/1/',
+                        '/dataset/variables/url/a/subvariables/2/'
+                    ]
+                }
+            ]
+        }
+
     def test_array_expansion_single_subvariable(self):
         var_id = '0001'
         var_alias = 'hobbies'


### PR DESCRIPTION
When discussing with @alejandro-rivera we found that we can identify if arguments are subvariable ids by comparing with the ids of the subvariables before expanding the expression with nested **in** and **or** functions.

Now the expression is expanded only when one or more of the arguments doesn't match with the subvariables' ids, but when all arguments are subvariables then the expression maintains the any function and the references got transformed to urls.

@jjdelc Can you confirm that this is the expected behaviour?

See the test: https://github.com/Crunch-io/scrunch/compare/master...dmonroy:has-any-processing?expand=1#diff-f7d0b592b836e5fde287dc1fc1993e74R1485