### PR TITLE
allow labels in expressions

### DIFF
--- a/docs/intro.md
+++ b/docs/intro.md
@@ -98,8 +98,6 @@ For example, assume that we have `disposition` as the alias of a variable
 in the dataset (assigned to the Python object `ds`). Then apply the exclusion 
 filter:
 
-[comment]: TODO: Allow filters using category labels!
-
 ```python
 ds.exclude("disposition != 'complete'")
 ```

--- a/scrunch/expressions.py
+++ b/scrunch/expressions.py
@@ -391,6 +391,49 @@ def process_expr(obj, ds):
     base_url = ds.self
     variables = get_dataset_variables(ds)
 
+    def ensure_category_ids(subitems, variables=variables):
+        var_id = None
+        var_value = None
+        _subitems = []
+
+        def variable_id(variable_url):
+            return variable_url.split('/')[-2]
+
+        def category_ids(var_id, var_value, variables=variables):   
+            value = None
+            if isinstance(var_value, list) or isinstance(var_value, tuple):
+                # {'values': [val1, val2, ...]}
+                value = []
+                for val in var_value:
+                    if str(val).isdigit():
+                        # val1 is an id already
+                        value.append(val)
+                        continue
+                    for var in variables:
+                        if variables[var]['id'] == var_id:
+                            for cat in variables[var].categories:
+                                if cat['name'] == val:
+                                    value.append(cat['numeric_value'])
+
+            elif isinstance(var_value, str):
+                for var in variables:
+                    if variables[var]['id'] == var_id:
+                        for cat in variables[var].categories:
+                            if cat['name'] == var_value:
+                                value = cat['numeric_value']
+            else:
+                return var_value
+            return value
+
+        for item in subitems:
+            if isinstance(item, dict) and 'variable' in item:
+                var_id = variable_id(item['variable'])
+            elif isinstance(item, dict) and 'value' in item:
+                item['value'] = category_ids(var_id, item['value'])
+            _subitems.append(item)
+
+        return _subitems
+
     def _process(obj, variables):
         op = None
         arrays = []
@@ -410,6 +453,14 @@ def process_expr(obj, ds):
                         elif 'value' in subitem:
                             values.append(subitem)
                     subitems.append(subitem)
+
+                has_value = any('value' in item for item in subitems
+                                if not str(item).isdigit())
+
+                has_variable = any('variable' in item for item in subitems
+                                   if not str(item).isdigit())
+                if has_value and has_variable:
+                    subitems = ensure_category_ids(subitems)
                 obj[key] = subitems
             elif key == 'variable':
                 var = variables.get(val)

--- a/scrunch/tests/test_expressions.py
+++ b/scrunch/tests/test_expressions.py
@@ -2171,6 +2171,164 @@ class TestExpressionProcessing(TestCase):
             ]
         }
 
+    def test_label_expression_single(self):
+        var_id = '0001'
+        var_alias = 'hobbies'
+        var_type = 'categorical'
+        var_url = '%svariables/%s/' % (self.ds_url, var_id)
+        categories = [
+            {
+                'name': 'mocking',
+                'numeric_value': 1
+            }
+        ]
+
+        # Mock the dataset.
+        _get_func = self._build_get_func(
+            id=var_id, type=var_type, alias=var_alias, is_subvar=False)
+
+        _var_mock = mock.MagicMock()
+        _var_mock.entity.self = var_url
+        _var_mock.__getitem__.side_effect = _get_func
+        _var_mock.get.side_effect = _get_func
+        _var_mock.categories = categories
+
+        def _session_get(*args, **kwargs):
+            if args[0] == '%stable/' % self.ds_url:
+                return self.CrunchPayload({
+                    'metadata': {
+                        var_id: _var_mock
+                    }
+                })
+            return self.CrunchPayload()
+
+        ds = mock.MagicMock()
+        ds.self = self.ds_url
+        ds.fragments.table = '%stable/' % self.ds_url
+        ds.session.get.side_effect = _session_get
+
+        expr = "hobbies == 'mocking'"
+        expr_obj = process_expr(parse_expr(expr), ds)
+        assert expr_obj == {
+            'function': '==',
+            'args': [
+                {
+                    'variable': var_url
+                },
+                {
+                    'value': 1
+                }
+            ]
+        }
+
+    def test_label_expression_list(self):
+        var_id = '0001'
+        var_alias = 'hobbies'
+        var_type = 'categorical'
+        var_url = '%svariables/%s/' % (self.ds_url, var_id)
+        categories = [
+            {
+                'name': 'mocking',
+                'numeric_value': 1
+            },
+            {
+                'name': 'coding',
+                'numeric_value': 2
+            },
+        ]
+
+        # Mock the dataset.
+        _get_func = self._build_get_func(
+            id=var_id, type=var_type, alias=var_alias, is_subvar=False)
+
+        _var_mock = mock.MagicMock()
+        _var_mock.entity.self = var_url
+        _var_mock.__getitem__.side_effect = _get_func
+        _var_mock.get.side_effect = _get_func
+        _var_mock.categories = categories
+
+        def _session_get(*args, **kwargs):
+            if args[0] == '%stable/' % self.ds_url:
+                return self.CrunchPayload({
+                    'metadata': {
+                        var_id: _var_mock
+                    }
+                })
+            return self.CrunchPayload()
+
+        ds = mock.MagicMock()
+        ds.self = self.ds_url
+        ds.fragments.table = '%stable/' % self.ds_url
+        ds.session.get.side_effect = _session_get
+
+        expr = "hobbies in ['mocking', 'coding']"
+        expr_obj = process_expr(parse_expr(expr), ds)
+        assert expr_obj == {
+            'function': 'in',
+            'args': [
+                {
+                    'variable': var_url
+                },
+                {
+                    'value': [1, 2]
+                }
+            ]
+        }
+
+    def test_label_expression_tuple(self):
+        var_id = '0001'
+        var_alias = 'hobbies'
+        var_type = 'categorical'
+        var_url = '%svariables/%s/' % (self.ds_url, var_id)
+        categories = [
+            {
+                'name': 'mocking',
+                'numeric_value': 1
+            },
+            {
+                'name': 'coding',
+                'numeric_value': 2
+            },
+        ]
+
+        # Mock the dataset.
+        _get_func = self._build_get_func(
+            id=var_id, type=var_type, alias=var_alias, is_subvar=False)
+
+        _var_mock = mock.MagicMock()
+        _var_mock.entity.self = var_url
+        _var_mock.__getitem__.side_effect = _get_func
+        _var_mock.get.side_effect = _get_func
+        _var_mock.categories = categories
+
+        def _session_get(*args, **kwargs):
+            if args[0] == '%stable/' % self.ds_url:
+                return self.CrunchPayload({
+                    'metadata': {
+                        var_id: _var_mock
+                    }
+                })
+            return self.CrunchPayload()
+
+        ds = mock.MagicMock()
+        ds.self = self.ds_url
+        ds.fragments.table = '%stable/' % self.ds_url
+        ds.session.get.side_effect = _session_get
+
+        expr = "hobbies in ('mocking', 'coding')"
+        expr_obj = process_expr(parse_expr(expr), ds)
+        assert expr_obj == {
+            'function': 'in',
+            'args': [
+                {
+                    'variable': var_url
+                },
+                {
+                    'value': [1, 2]
+                }
+            ]
+        }
+
 
 class TestExpressionPrettify(TestCase):
 


### PR DESCRIPTION
this PR converts labels in expression objects into their respective numeric value:

examples:
- `ds.exclude("gender == 'male'")`
- `ds.exclude("hobbies in ['hobby1', 'hobby2']")`
- `ds.exclude("hobbies in ('hobby1', 'hobby2')")`
- `ds.exclude("hobbies != 'hobby2'")`