### PR TITLE
Make it work with python versions 3.5 and 3.6 (tests was failing with RuntimeError)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ language: python
 python:
   - 2.7
   - 3.4
+  - 3.5
+  - 3.6
 
 sudo: false
 

--- a/scrunch/datasets.py
+++ b/scrunch/datasets.py
@@ -705,7 +705,8 @@ class Group(AbstractContainer):
             raise NotImplementedError('Deleting the root Group is not allowed.')
 
         # Before deleting the Group, move all its elements to the root.
-        for element_name, obj in self.elements.items():
+        elements = self.elements.copy()
+        for element_name, obj in elements.items():
             if isinstance(obj, Group):
                 obj.parent = self.order.graph
             self.order.graph.elements[element_name] = obj


### PR DESCRIPTION
running the test suite using python versions 3.5 and 3.6 caused the following error:
```>       for element_name, obj in self.elements.items():
E       RuntimeError: OrderedDict mutated during iteration

```

This is because items on the `self.elements` were deleted during the iteration and is not allowed for OrderedDict objects on newer python versions.

This pull request ensures all test pass on python versions 2.7, 3.4, 3.5 and 3.6.

@alejandro-rivera I saw you worked on this feature, can you confirm I'm understanding correctly the logic behind the `delete` method and my changes wouldn't cause any issue.