### PR TITLE
Extend exclusion filters

### DIFF
--- a/scrunch/datasets.py
+++ b/scrunch/datasets.py
@@ -1075,7 +1075,7 @@ class Dataset(object):
             # on the expr to get rid of eventually unneeded parantheses
             fmt = '({}) {} ({})'
             expr = prettify(parse_expr(
-                fmt.format(_filter, extend,
+                fmt.format(_filter, extend.lower(),
                            prettify(parse_expr(expr)))))
 
         if isinstance(expr, six.string_types):

--- a/scrunch/expressions.py
+++ b/scrunch/expressions.py
@@ -575,6 +575,7 @@ def prettify(expr, ds=None):
 
     operators = BINARY_FUNC_OPERATORS + COMPARISSON_OPERATORS
     methods = {m[1]: m[0] for m in CRUNCH_METHOD_MAP.items()}
+    functions = {f[1]: f[0] for f in CRUNCH_FUNC_MAP.items()}
 
     def _resolve_variable(var):
         is_url = validate_variable_url(var)
@@ -619,6 +620,8 @@ def prettify(expr, ds=None):
             result = '%s.%s(%s)' % (
                 args[0], methods[f], ', '.join(str(x) for x in args[1:])
             )
+        elif f in functions:
+            result = '%s(%s)' % (functions[f], args[0])
         else:
             raise Exception('Unknown function "%s"' % f)
 


### PR DESCRIPTION
This PR enables the current exclude Dataset method to extend an existing exclusion filter.

usage:
`ds.exclude(<expression>, 'and'/'or')`
`ds.exclude(<expression>, extend='and'/'or')`