### PR TITLE
Prevent editing categories on derived variables. Fix the previous ime…

### DIFF
--- a/scrunch/categories.py
+++ b/scrunch/categories.py
@@ -24,13 +24,15 @@ class Category:
         return {attr: getattr(self, attr) for attr in self.ATTRIBUTES}
 
     def edit(self, **kwargs):
+        if self.variable.body.get('derivation'):
+            raise TypeError("Cannot edit categories on derived variables. Re-derive with the appropriate expression")
         extra_attrs = set(kwargs.keys()) - self.MUTABLE_ATTRIBUTES
         if extra_attrs:
             raise ValueError("Cannot edit the following attributes: %s" % ', '.join(extra_attrs) )
 
         self.fill(kwargs)
         categories = [self.as_dict() if cat['id'] == self.id else cat
-                      for cat in self.variable.categories]
+                      for cat in self.variable.body['categories']]
         self.variable.edit(categories=categories)
         self.variable.refresh()
 
@@ -39,11 +41,12 @@ class CategoryList(OrderedDict):
     def __init__(self, variable_resource):
         self.variable = variable_resource
         categories = [(cat['id'], Category(variable_resource, cat))
-                      for cat in variable_resource.categories]
+                      for cat in variable_resource.body['categories']]
         super(CategoryList, self).__init__(categories)
 
     def order(self, *new_order):
-        categories = sorted(self.variable.categories, key=lambda c: new_order.index(c['id']))
+        categories = sorted(self.variable.body['categories'],
+            key=lambda c: new_order.index(c['id']))
         self.variable.edit(categories=categories)
         self.variable.refresh()
 

--- a/scrunch/datasets.py
+++ b/scrunch/datasets.py
@@ -1425,6 +1425,7 @@ class Variable(object):
     # We won't expose owner and private
     # categories in immutable. IMO it should be handled separately
     _ENTITY_ATTRIBUTES = _MUTABLE_ATTRIBUTES | _IMMUTABLE_ATTRIBUTES
+    _OVERRIDDEN_ATTRIBUTES = {'categories'}
 
     CATEGORICAL_TYPES = {'categorical', 'multiple_response', 'categorical_array'}
 
@@ -1434,8 +1435,12 @@ class Variable(object):
         self.dataset = Dataset(dataset_resource)
 
     def __getattr__(self, item):
-        if item in self._ENTITY_ATTRIBUTES:
-            return self.resource.body[item]  # Has to exist
+        if item in self._ENTITY_ATTRIBUTES - self._OVERRIDDEN_ATTRIBUTES:
+            try:
+                return self.resource.body[item]  # Has to exist
+            except KeyError:
+                raise AttributeError("Variable does not have attribute %s" % item)
+        return super(Variable, self).__getattribute__(item)
 
     def edit(self, **kwargs):
         for key in kwargs:
@@ -1455,8 +1460,8 @@ class Variable(object):
 
     @property
     def categories(self):
-        if self.resource.type not in self.CATEGORICAL_TYPES:
-            raise TypeError("Variable of type %s do not have categories" % self.resource.type)
+        if self.resource.body['type'] not in self.CATEGORICAL_TYPES:
+            raise TypeError("Variable of type %s do not have categories" % self.resource.body.type)
         if self._categories is None:
             self._categories = CategoryList(self.resource)
         return self._categories

--- a/scrunch/tests/test_categories.py
+++ b/scrunch/tests/test_categories.py
@@ -53,11 +53,6 @@ class TestCategories(TestCase):
             # Same as above, reusing the existing value from API still
             {'numeric_value': None, 'missing': True, 'id': -1, 'name': 'No Data'}
         ])
-        x = [
-            {'numeric_value': None, 'missing': False, 'id': 1, 'name': 'Female'},
-            {'numeric_value': None, 'selected': False, 'id': 2, 'missing': False,'name': 'Hombre'},
-            {'numeric_value': None, 'missing': True, 'id': -1, 'name': 'No Data'}
-        ]
 
         # Try to change the ID
         with self.assertRaises(ValueError) as err:
@@ -81,6 +76,20 @@ class TestCategories(TestCase):
             variable.categories[1].edit(name='Mujer')
         self.assertEqual(err.exception.message,
             "Cannot edit categories on derived variables. Re-derive with the appropriate expression")
+
+        # Try again with an empty derivation
+        resource = EditableMock(body=dict(
+            categories=TEST_CATEGORIES(),
+            type='categorical',
+            derivation={}  # Empty
+        ))
+        variable = Variable(resource, MagicMock())
+        variable.categories[1].edit(name='Mujer')
+        resource._edit.assert_called_with(categories=[
+            {'numeric_value': None, 'selected': False, 'id': 1, 'missing': False, 'name': 'Mujer'},
+            {'numeric_value': None, 'missing': False, 'id': 2, 'name': 'Male'},
+            {'numeric_value': None, 'missing': True, 'id': -1, 'name': 'No Data'}
+        ])
 
 
 class TestCategoryList(TestCase):

--- a/scrunch/tests/test_categories.py
+++ b/scrunch/tests/test_categories.py
@@ -1,3 +1,4 @@
+import pytest
 from mock import MagicMock
 from unittest import TestCase
 from scrunch.datasets import Variable
@@ -72,10 +73,10 @@ class TestCategories(TestCase):
             derivation={'function': 'derivation_function'}
         ))
         variable = Variable(resource, MagicMock())
-        with self.assertRaises(TypeError) as err:
+
+        error_msg = "Cannot edit categories on derived variables. Re-derive with the appropriate expression"
+        with pytest.raises(TypeError, message=error_msg):
             variable.categories[1].edit(name='Mujer')
-        self.assertEqual(err.exception.message,
-            "Cannot edit categories on derived variables. Re-derive with the appropriate expression")
 
         # Try again with an empty derivation
         resource = EditableMock(body=dict(


### PR DESCRIPTION
The previous implementation on `Category().edit` was wrong because the resource attributes are inside its `.body` and not straight on it. 

On top of that, the actual ticket, to prevent editing categories if the variable is derived (has a `derivation`)