### PR TITLE
honor the new way subreferences are serialized as a dict of `{varid:v…

### DIFF
--- a/scrunch/expressions.py
+++ b/scrunch/expressions.py
@@ -384,9 +384,10 @@ def get_dataset_variables(ds):
         variables[var['alias']] = var
 
         if var['type'] in ('categorical_array', 'multiple_response'):
-            for i, subvar in enumerate(var.get('subreferences', [])):
+            subreferences = var.get('subreferences', {})
+            for subvar_id, subvar in subreferences.items():
                 subvar['is_subvar'] = True
-                subvar['id'] = var['subvariables'][i]
+                subvar['id'] = subvar_id
                 subvar['parent_id'] = _id
                 subvar['type'] = 'categorical'
                 subvar['description'] = ''

--- a/scrunch/tests/test_expressions.py
+++ b/scrunch/tests/test_expressions.py
@@ -1468,14 +1468,11 @@ class TestExpressionProcessing(TestCase):
             '0001',
             '0002'
         ]
-        subreferences = [
-            {
-                'alias': 'hobbies_1'
-            },
-            {
-                'alias': 'hobbies_2'
-            }
-        ]
+
+        subreferences = {
+            '0001': {'alias': 'hobbies_1'},
+            '0002': {'alias': 'hobbies_2'},
+        }
 
         table_mock = mock.MagicMock(metadata={
             var_id: {
@@ -1513,11 +1510,10 @@ class TestExpressionProcessing(TestCase):
         subvariables = [
             '0001'
         ]
-        subreferences = [
-            {
-                'alias': 'hobbies_1'
-            }
-        ]
+
+        subreferences = {
+            '0001': {'alias': 'hobbies_1'},
+        }
 
         table_mock = mock.MagicMock(metadata={
             var_id: {
@@ -1627,20 +1623,12 @@ class TestExpressionProcessing(TestCase):
             '0003',
             '0004'
         ]
-        subreferences = [
-            {
-                'alias': 'hobbies_1'
-            },
-            {
-                'alias': 'hobbies_2'
-            },
-            {
-                'alias': 'hobbies_3'
-            },
-            {
-                'alias': 'hobbies_4'
-            }
-        ]
+        subreferences = {
+            '0001': {'alias': 'hobbies_1'},
+            '0002': {'alias': 'hobbies_2'},
+            '0003': {'alias': 'hobbies_3'},
+            '0004': {'alias': 'hobbies_4'}
+        }
 
         table_mock = mock.MagicMock(metadata={
             var_id: {
@@ -2058,20 +2046,13 @@ class TestExpressionProcessing(TestCase):
             '0003',
             '0004'
         ]
-        subreferences = [
-            {
-                'alias': 'hobbies_1'
-            },
-            {
-                'alias': 'hobbies_2'
-            },
-            {
-                'alias': 'hobbies_3'
-            },
-            {
-                'alias': 'hobbies_4'
-            }
-        ]
+
+        subreferences = {
+            '0001': {'alias': 'hobbies_1'},
+            '0002': {'alias': 'hobbies_2'},
+            '0003': {'alias': 'hobbies_3'},
+            '0004': {'alias': 'hobbies_4'}
+        }
 
         table_mock = mock.MagicMock(metadata={
             var_id: {


### PR DESCRIPTION
started to happen after latest release in crunch api

```
Traceback (most recent call last):
  File "scrunch/tests/integration/scrunch_workflow_integration_test.py", line 936, in <module>
    main()
  File "scrunch/tests/integration/scrunch_workflow_integration_test.py", line 358, in main
    dataset.exclude('identity > 5')
  File "/Users/dmo/Work/YG/crunch/scrunch/scrunch/datasets.py", line 897, in exclude
    expr_obj = process_expr(expr_obj, self.resource)  # cause we need URLs
  File "/Users/dmo/Work/YG/crunch/scrunch/scrunch/expressions.py", line 408, in process_expr
    variables = get_dataset_variables(ds)
  File "/Users/dmo/Work/YG/crunch/scrunch/scrunch/expressions.py", line 389, in get_dataset_variables
    subvar['is_subvar'] = True
TypeError: 'str' object does not support item assignment
```

Fixed with this PR