### PR TITLE
Descriptive error messages for the expression parser

### DIFF
--- a/scrunch/expressions.py
+++ b/scrunch/expressions.py
@@ -231,8 +231,12 @@ def parse_expr(expr):
                 # The variable.
                 _id_node = fields[0][1]
                 if not isinstance(_id_node, ast.Name):
-                    # TODO: what should be the right error message for this?
-                    raise ValueError
+                    msg = (
+                        'calling methods of "{}" object not allowed, '
+                        'variable name expected.'
+                    ).format(type(_id_node).__name__)
+                    raise SyntaxError(msg)
+
                 _id = _parse(_id_node, parent=node)
 
                 # The 'method'.

--- a/scrunch/expressions.py
+++ b/scrunch/expressions.py
@@ -297,8 +297,7 @@ def parse_expr(expr):
                         op = CRUNCH_FUNC_MAP[_id]
                     elif _name == 'ops':
                         if len(_val) != 1:
-                            # TODO: what should be the right error message for this?
-                            raise ValueError
+                            raise ValueError('only one logical operator at a time')
                         op = _parse(_val[0], parent=node)
                     elif _name == 'comparators' or _name == 'args':  # right
                         if len(_val) == 0:
@@ -306,8 +305,7 @@ def parse_expr(expr):
 
                         if func_type == 'method':
                             if len(_val) > 1:
-                                # TODO: what should be the right error message for this?
-                                raise ValueError
+                                raise ValueError('1 argument expected, got {}'.format(len(_val)))
 
                             if op == 'duplicates':
                                 # No parameters allowed for 'duplicates'.

--- a/scrunch/tests/test_expressions.py
+++ b/scrunch/tests/test_expressions.py
@@ -12,6 +12,12 @@ from scrunch.expressions import prettify
 
 class TestExpressionParsing(TestCase):
 
+    def test_any_of_str(self):
+        expr = '"age".any(1,2)'
+
+        with pytest.raises(SyntaxError) as err:
+            parse_expr(expr)
+
     def test_in_value_error(self):
         expr = "age in [{}, 1, 2]"
         with pytest.raises(ValueError) as err:


### PR DESCRIPTION
_sorry for the typo in the branch name_.

I've added verbose messages for all exceptions thrown by the expression parser, except for one that I'm not able to test.

@xbito can you confirm messages are fine?