### PR TITLE
Fixes #87: makes possible to iterate over all elements in the dataset order

### DIFF
--- a/scrunch/datasets.py
+++ b/scrunch/datasets.py
@@ -397,6 +397,26 @@ class Group(object):
     def __repr__(self):
         return self.__str__()
 
+    def __iter__(self):
+        return self.itervalues()
+
+    def itervalues(self):
+        for item in self.elements.values():
+            yield item
+
+    def iterkeys(self):
+        for key in self.elements.keys():
+            yield key
+
+    def keys(self):
+        return list(self.iterkeys())
+
+    def values(self):
+        return list(self.itervalues())
+
+    def items(self):
+        return zip(self.iterkeys(), self.itervalues())
+
     def __getitem__(self, path):
         if not isinstance(path, six.string_types):
             raise TypeError('arg 1 must be a string')
@@ -810,6 +830,24 @@ class Order(object):
 
     def __repr__(self):
         return self.__str__()
+
+    def __iter__(self):
+        return self.graph.itervalues()
+
+    def itervalues(self):
+        return self.graph.itervalues()
+
+    def iterkeys(self):
+        return self.graph.iterkeys()
+
+    def keys(self):
+        return self.graph.keys()
+
+    def values(self):
+        return self.graph.values()
+
+    def items(self):
+        return self.graph.items()
 
     def __getitem__(self, item):
         return self.graph[item]

--- a/scrunch/tests/test_datasets.py
+++ b/scrunch/tests/test_datasets.py
@@ -3102,6 +3102,68 @@ class TestHierarchicalOrder(TestCase):
         assert isinstance(ds.order['|'], scrunch.datasets.Group)
         assert ds._hier_calls == 2
 
+    def test_order_iteration(self):
+        ds = self.ds
+
+        # consume all items in the dataset order
+        items = [item for item in ds.order]
+
+        assert isinstance(items[0], mock.MagicMock)  # id
+        assert isinstance(items[1], mock.MagicMock)  # hobbies
+        assert isinstance(items[2], scrunch.datasets.Group)  # Account
+        assert isinstance(items[3], mock.MagicMock)  # music
+        assert isinstance(items[4], mock.MagicMock)  # religion
+
+    def test_order_iteration_values(self):
+        ds = self.ds
+
+        items = ds.order.values()
+
+        assert isinstance(items[0], mock.MagicMock)  # id
+        assert isinstance(items[1], mock.MagicMock)  # hobbies
+        assert isinstance(items[2], scrunch.datasets.Group)  # Account
+        assert isinstance(items[3], mock.MagicMock)  # music
+        assert isinstance(items[4], mock.MagicMock)  # religion
+
+    def test_order_iteration_itervalues(self):
+        ds = self.ds
+
+        items = [item for item in ds.order.itervalues()]
+
+        assert isinstance(items[0], mock.MagicMock)  # id
+        assert isinstance(items[1], mock.MagicMock)  # hobbies
+        assert isinstance(items[2], scrunch.datasets.Group)  # Account
+        assert isinstance(items[3], mock.MagicMock)  # music
+        assert isinstance(items[4], mock.MagicMock)  # religion
+
+    def test_order_iteration_keys(self):
+        ds = self.ds
+
+        keys = ds.order.keys()
+        assert keys == ['id', 'hobbies', 'Account', 'music', 'religion']
+
+    def test_order_iteration_iterkeys(self):
+        ds = self.ds
+
+        keys = [k for k in ds.order.iterkeys()]
+        assert keys == ['id', 'hobbies', 'Account', 'music', 'religion']
+
+    def test_order_iteration_items(self):
+        ds = self.ds
+
+        keys = []
+        items = []
+        for k, v in ds.order.items():
+            keys.append(k)
+            items.append(v)
+
+        assert keys == ['id', 'hobbies', 'Account', 'music', 'religion']
+        assert isinstance(items[0], mock.MagicMock)  # id
+        assert isinstance(items[1], mock.MagicMock)  # hobbies
+        assert isinstance(items[2], scrunch.datasets.Group)  # Account
+        assert isinstance(items[3], mock.MagicMock)  # music
+        assert isinstance(items[4], mock.MagicMock)  # religion
+
 
 class TestDatasetSettings(TestCase):
 


### PR DESCRIPTION
Now is possible to iterate over all elements in the dataset's order, as described in #87, see the tests I've added here: https://github.com/Crunch-io/scrunch/compare/bugfix/iterate-dataset-order?expand=1#diff-ae872301ff713c915a36ec3866811bb9