### PR TITLE
Bugfix/subvariable iteration order

### DIFF
--- a/scrunch/datasets.py
+++ b/scrunch/datasets.py
@@ -1879,11 +1879,9 @@ class DatasetSubvariablesMixin(DatasetVariablesMixin):
         """
         Iterable of subvariable aliases
         """
-        values = self.resource.subvariables.index.values()
-        sort_func = lambda x: x['id']
-
-        for svar in sorted(values, key=sort_func):
-            yield svar
+        sv_index = self.resource.subvariables.index
+        for sv in self.resource['body']['subvariables']:
+            yield sv_index[sv]
 
     def __len__(self):
         return len(self.resource.subvariables.index)

--- a/scrunch/datasets.py
+++ b/scrunch/datasets.py
@@ -1877,7 +1877,7 @@ class DatasetSubvariablesMixin(DatasetVariablesMixin):
 
     def __iter__(self):
         """
-        Iterable of subvariable aliases
+        Iterable of ordered subvariables
         """
         sv_index = self.resource.subvariables.index
         for sv in self.resource['body']['subvariables']:

--- a/scrunch/datasets.py
+++ b/scrunch/datasets.py
@@ -1879,7 +1879,10 @@ class DatasetSubvariablesMixin(DatasetVariablesMixin):
         """
         Iterable of subvariable aliases
         """
-        for svar in self.resource.subvariables.index.values():
+        values = self.resource.subvariables.index.values()
+        sort_func = lambda x: x['id']
+
+        for svar in sorted(values, key=sort_func):
             yield svar
 
     def __len__(self):

--- a/scrunch/tests/test_datasets.py
+++ b/scrunch/tests/test_datasets.py
@@ -3419,6 +3419,35 @@ class TestVariableIterator(TestDatasetBase):
         ds = Dataset(ds_mock)
         assert isinstance(ds.values(), list)
 
+    def test_subvar_order(self):
+        subvars = {
+            # Intentionally unordered
+            '0003': {
+                'id': '0003',
+                'alias': 'subvar_3'
+            },
+            '0001': {
+                'id': '0001',
+                'alias': 'subvar_1'
+            },
+            '0004': {
+                'id': '0004',
+                'alias': 'subvar_4'
+            },
+            '0002': {
+                'id': '0002',
+                'alias': 'subvar_2'
+            },
+        }
+        ds = mock.MagicMock()
+        var_tuple = mock.MagicMock()
+        var_tuple.entity.subvariables.index = subvars
+
+        v = Variable(var_tuple=var_tuple, dataset=ds)
+
+        all_ids = [sv['id'] for sv in v]
+        assert all_ids == ['0001', '0002', '0003', '0004']
+
 
 class TestFilter(TestDatasetBase, TestCase):
 

--- a/scrunch/tests/test_datasets.py
+++ b/scrunch/tests/test_datasets.py
@@ -3420,6 +3420,12 @@ class TestVariableIterator(TestDatasetBase):
         assert isinstance(ds.values(), list)
 
     def test_subvar_order(self):
+        subvars_order = [
+            '0001',
+            '0002',
+            '0003',
+            '0004'
+        ]
         subvars = {
             # Intentionally unordered
             '0003': {
@@ -3439,8 +3445,15 @@ class TestVariableIterator(TestDatasetBase):
                 'alias': 'subvar_2'
             },
         }
+        body = dict(subvariables=subvars_order)
+
+        def getitem(key):
+            if key == 'body':
+                return body
+
         ds = mock.MagicMock()
         var_tuple = mock.MagicMock()
+        var_tuple.entity.__getitem__.side_effect = getitem
         var_tuple.entity.subvariables.index = subvars
 
         v = Variable(var_tuple=var_tuple, dataset=ds)


### PR DESCRIPTION
when iterating the subvariables of a variable, the iterator now yields the subvariables ordered by id