### PR TITLE
`ds.create_categorical` now supports `notes`

### DIFF
--- a/scrunch/datasets.py
+++ b/scrunch/datasets.py
@@ -1249,7 +1249,8 @@ class Dataset(ReadOnly, DatasetVariablesMixin):
         new_filter = self.resource.filters.create(payload)
         return self.filters[new_filter.body['name']]
 
-    def create_single_response(self, categories, name, alias, description='', missing=True):
+    def create_single_response(self, categories, name, alias, description='',
+                               notes='', missing=True):
         """
         Creates a categorical variable deriving from other variables.
         Uses Crunch's `case` function.
@@ -1291,7 +1292,8 @@ class Dataset(ReadOnly, DatasetVariablesMixin):
                        body=dict(alias=alias,
                                  name=name,
                                  expr=expr,
-                                 description=description))
+                                 description=description,
+                                 notes=notes))
 
         new_var = self.resource.variables.create(payload)
         # needed to update the variables collection
@@ -1299,7 +1301,8 @@ class Dataset(ReadOnly, DatasetVariablesMixin):
         # return the variable instance
         return self[new_var['body']['alias']]
 
-    def create_multiple_response(self, responses, name, alias, description=''):
+    def create_multiple_response(self, responses, name, alias, description='',
+                                 notes=''):
         """
         Creates a Multiple response (array) using a set of rules for each
          of the responses(subvariables).
@@ -1318,6 +1321,7 @@ class Dataset(ReadOnly, DatasetVariablesMixin):
                 'name': name,
                 'alias': alias,
                 'description': description,
+                'notes': notes,
                 'derivation': {
                     'function': 'array',
                     'args': [{
@@ -1883,19 +1887,22 @@ class Dataset(ReadOnly, DatasetVariablesMixin):
             return wait_progress(r=progress, session=self.resource.session, entity=self)
         return progress.json()['value']
 
-    def create_categorical(self, categories, alias, name, multiple, description=''):
+    def create_categorical(self, categories, alias, name, multiple,
+                           description='', notes=''):
         """
-        Used to create new categorical variables using Crunchs's `case` function.
+        Used to create new categorical variables using Crunchs's `case` func
 
         Will create either categorical variables or multiple response depending
         on the `multiple` parameter.
         """
         if multiple:
             return self.create_multiple_response(
-                categories, alias=alias, name=name, description=description)
+                categories, alias=alias, name=name, description=description,
+                notes=notes)
         else:
             return self.create_single_response(
-                categories, alias=alias, name=name, description=description)
+                categories, alias=alias, name=name, description=description,
+                notes=notes)
 
 
 class DatasetSubvariablesMixin(DatasetVariablesMixin):

--- a/scrunch/datasets.py
+++ b/scrunch/datasets.py
@@ -1250,7 +1250,7 @@ class Dataset(ReadOnly, DatasetVariablesMixin):
         return self.filters[new_filter.body['name']]
 
     def create_single_response(self, categories, name, alias, description='',
-                               notes='', missing=True):
+                               missing=True, notes=''):
         """
         Creates a categorical variable deriving from other variables.
         Uses Crunch's `case` function.
@@ -1890,7 +1890,8 @@ class Dataset(ReadOnly, DatasetVariablesMixin):
     def create_categorical(self, categories, alias, name, multiple,
                            description='', notes=''):
         """
-        Used to create new categorical variables using Crunchs's `case` func
+        Used to create new categorical variables using Crunchs's `case`
+        function
 
         Will create either categorical variables or multiple response depending
         on the `multiple` parameter.

--- a/scrunch/tests/test_datasets.py
+++ b/scrunch/tests/test_datasets.py
@@ -1364,6 +1364,7 @@ class TestRecode(TestDatasetBase):
             'element': 'shoji:entity',
             'body': {
                 'description': '',
+                'notes': '',
                 'alias': 'cat',
                 'name': 'My cat',
                 'expr': {
@@ -1484,6 +1485,7 @@ class TestRecode(TestDatasetBase):
             'body': {
                 'alias': 'mr',
                 'description': '',
+                'notes': '',
                 'name': 'my mr',
                 'derivation': {
                     'function': 'array',

--- a/scrunch/tests/test_recodes.py
+++ b/scrunch/tests/test_recodes.py
@@ -325,6 +325,7 @@ class TestRecode(TestCase):
                 'name': 'Sexuality 2',
                 'alias': 'sexuality2',
                 'description': '',
+                'notes': '',
                 'expr': {
                     'function': 'case',
                     'args': [{
@@ -425,7 +426,8 @@ class TestRecode(TestCase):
                 'type': 'multiple_response',
                 'id': '0001',
                 'categories': categories,
-                'description': 'Multiple Response Example'
+                'description': 'Multiple Response Example',
+                'notes': '',
             }
 
         })
@@ -434,6 +436,7 @@ class TestRecode(TestCase):
                 'id': '00001',
                 'alias': 'sexuality',
                 'type': 'categorical',
+                'notes': '',
                 'categories': categories
             }
         })
@@ -462,6 +465,7 @@ class TestRecode(TestCase):
             'body': {
                 'name': 'Q1_recoded',
                 'description': '',
+                'notes': '',
                 'alias': 'Q1_recoded',
                 'derivation': {
                     'function': 'array',


### PR DESCRIPTION
and pass the param through to `create_single/multiple_response`

fixes #89 