### PR TITLE
Hotfix/range typeerror py27

### DIFF
--- a/scrunch/tests/test_recodes.py
+++ b/scrunch/tests/test_recodes.py
@@ -112,6 +112,26 @@ class TestCombine(TestCase):
         # subvar_url * 4 because we used the same mock for all subvars
         assert modified_map[0]['combined_ids'] == [subvar1_url] * 4
 
+    def test_validate_integer(self):
+        test_map = {
+            1: 1
+        }
+        test_cats = {
+            1: "China"
+        }
+
+        ds_res_mock = mock.MagicMock()
+        variable_mock = mock.MagicMock()
+        subvar_mock = mock.MagicMock(entity_url=subvar1_url)
+        # mock the call to entity, this will happen on Variable.resource
+        variable_mock.entity.subvariables.by.return_value = {
+            'parent_1': subvar_mock
+        }
+        parent_var = Variable(variable_mock, ds_res_mock)
+        modified_map = responses_from_map(parent_var, test_map, test_cats, 'test', 'parent')
+        # subvar_url * 4 because we used the same mock for all subvars
+        assert modified_map[0]['combined_ids'] == [subvar1_url]
+
     def test_combine_categories_unknown_alias(self):
         resource = mock.MagicMock()
         resource.body = {'name': 'mocked_dataset'}

--- a/scrunch/variables.py
+++ b/scrunch/variables.py
@@ -19,7 +19,15 @@ def validate_variable_url(url):
 
 def responses_from_map(variable, response_map, cat_names, alias, parent_alias):
     subvars = variable.resource.subvariables.by('alias')
-    _supported_iterable_types = (list, tuple, range)
+
+
+    # In python 2.7, range(...) returns a list, starting from python 3,
+    # range is a python type
+    if six.PY2:
+        _supported_iterable_types = (list, tuple)
+    else:
+        _supported_iterable_types = (list, tuple, range)
+
     try:
         responses = [
             {

--- a/scrunch/variables.py
+++ b/scrunch/variables.py
@@ -20,7 +20,6 @@ def validate_variable_url(url):
 def responses_from_map(variable, response_map, cat_names, alias, parent_alias):
     subvars = variable.resource.subvariables.by('alias')
 
-
     # In python 2.7, range(...) returns a list, starting from python 3,
     # range is a python type
     if six.PY2:


### PR DESCRIPTION
fixes the issue that happens on python 2.7 regarding `isinstance(x, (..., range))`

range(...) produces a list in python 2.7.