### PR TITLE
Added get_project to __init__.py to allow scrunch.get_project.

### DIFF
--- a/scrunch/__init__.py
+++ b/scrunch/__init__.py
@@ -1,5 +1,5 @@
 from pycrunch import connect
-from .datasets import get_dataset
+from .datasets import get_dataset, get_project
 
 from pkg_resources import get_distribution, DistributionNotFound
 try:

--- a/scrunch/tests/test_utilities.py
+++ b/scrunch/tests/test_utilities.py
@@ -3,9 +3,9 @@ import mock
 
 import scrunch
 from scrunch.variables import validate_variable_url
+from scrunch import get_project
 from scrunch.datasets import (get_dataset, Dataset,
-                              get_user, get_project,
-                              Project, User)
+                              get_user, Project, User)
 
 
 @pytest.fixture(scope='function')


### PR DESCRIPTION
Allows `scrunch.get_project()` rather than `scrunch.datasets.get_project()`.