### PR TITLE
Fixes #92: pass the list of subvariable ids when using `create_catego…

### DIFF
--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -5,7 +5,6 @@ git+https://github.com/Crunch-io/pycrunch#pycrunch
 -e .
 
 #pycrunch
-pandas==0.19.2
 mock
 pytest
 pytest-sugar

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -5,7 +5,7 @@ git+https://github.com/Crunch-io/pycrunch#pycrunch
 -e .
 
 #pycrunch
-pandas
+pandas==0.19.2
 mock
 pytest
 pytest-sugar

--- a/scrunch/datasets.py
+++ b/scrunch/datasets.py
@@ -1453,12 +1453,19 @@ class Dataset(ReadOnly, DatasetVariablesMixin):
          of the responses(subvariables).
         """
         responses_map = collections.OrderedDict()
+        responses_map_ids = []
         for resp in responses:
             case = resp['case']
             if isinstance(case, six.string_types):
                 case = process_expr(parse_expr(case), self.resource)
-            responses_map['%04d' % resp['id']] = case_expr(case, name=resp['name'],
-                                                           alias='%s_%d' % (alias, resp['id']))
+
+            resp_id = '%04d' % resp['id']
+            responses_map_ids.append(resp_id)
+            responses_map[resp_id] = case_expr(
+                case,
+                name=resp['name'],
+                alias='%s_%d' % (alias, resp['id'])
+            )
 
         payload = {
             'element': 'shoji:entity',
@@ -1471,9 +1478,10 @@ class Dataset(ReadOnly, DatasetVariablesMixin):
                     'function': 'array',
                     'args': [{
                         'function': 'select',
-                        'args': [{
-                            'map': responses_map
-                        }]
+                        'args': [
+                            {'map': responses_map},
+                            {'value': responses_map_ids}
+                        ]
                     }]
                 }
             }

--- a/scrunch/tests/test_datasets.py
+++ b/scrunch/tests/test_datasets.py
@@ -1590,6 +1590,12 @@ class TestRecode(TestDatasetBase):
                                     }]
                                 }
                             }
+                        }, {
+                            'value': [
+                                '0001',
+                                '0002',
+                                '0003'
+                            ]
                         }]
                     }]
                 }

--- a/scrunch/tests/test_recodes.py
+++ b/scrunch/tests/test_recodes.py
@@ -544,6 +544,11 @@ class TestRecode(TestCase):
                                     }
                                 }
                             }
+                        }, {
+                            'value': [
+                                '0001',
+                                '0002'
+                            ]
                         }]
                     }]
                 }

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup_params = dict(
     author_email='dev@crunch.io',
     license='LGPL',
     install_requires=[
-        'pandas',
+        'pandas==0.19.2',
         'pycrunch>=0.4.0',
         'requests',
         'six',
@@ -44,7 +44,7 @@ setup_params = dict(
         'backports.unittest_mock',
         'isodate',
         'mock',
-        'pandas',
+        'pandas==0.19.2',
         'pytest',
         'pytest-cov',
         'pytest-sugar',

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup_params = dict(
     author_email='dev@crunch.io',
     license='LGPL',
     install_requires=[
-        'pandas==0.19.2',
+        'pandas<0.20',
         'pycrunch>=0.4.0',
         'requests',
         'six',
@@ -44,7 +44,6 @@ setup_params = dict(
         'backports.unittest_mock',
         'isodate',
         'mock',
-        'pandas==0.19.2',
         'pytest',
         'pytest-cov',
         'pytest-sugar',

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,6 @@
 envlist = py27, py34, py35, py36, flake8, isort
 [testenv]
 deps=
-    pandas==0.19.2
     mock
     pytest
     pytest-sugar

--- a/tox.ini
+++ b/tox.ini
@@ -2,8 +2,7 @@
 envlist = py27, py34, py35, py36, flake8, isort
 [testenv]
 deps=
-    git+https://github.com/Crunch-io/pycrunch#pycrunch
-    pandas
+    pandas==0.19.2
     mock
     pytest
     pytest-sugar


### PR DESCRIPTION
Fixes #92: pass the list of subvariable ids when using `create_categorical` in order to guarantee the subvariables order