### PR TITLE
create a batch with all pending messages by default

### DIFF
--- a/scrunch/datasets.py
+++ b/scrunch/datasets.py
@@ -1338,13 +1338,14 @@ class Dataset(ReadOnly, DatasetVariablesMixin):
         the rows to appear in the dataset instead of waiting for crunch
         automatic batcher process.
         """
-        self.resource.batches.create({
-            'element': 'shoji:entity',
-            'body': {
-                'stream': count,
-                'type': 'ldjson'
-            }
-        })
+        if bool(self.resource.stream.body.pending_messages):
+            self.resource.batches.create({
+                'element': 'shoji:entity',
+                'body': {
+                    'stream': count,
+                    'type': 'ldjson'
+                }
+            })
 
     def exclude(self, expr=None):
         """

--- a/scrunch/datasets.py
+++ b/scrunch/datasets.py
@@ -1332,7 +1332,7 @@ class Dataset(ReadOnly, DatasetVariablesMixin):
                                  {a: columns[a][x] for a in columns})
         return count
 
-    def push_rows(self, count):
+    def push_rows(self, count=None):
         """
         Batches in the rows that have been recently streamed. This forces
         the rows to appear in the dataset instead of waiting for crunch


### PR DESCRIPTION
That's just a minor change in order to create a batch with all pending messages by default. I was also wondering if we might want to `refresh` and check the `pending_messages` field of the `stream` endpoint first, in order to avoid the Exceptions raised by a 409 when there are no pending messages?