### PR TITLE
feature/crunchbox-display-settings

### DIFF
--- a/scrunch/datasets.py
+++ b/scrunch/datasets.py
@@ -2060,7 +2060,7 @@ class Dataset(ReadOnly, DatasetVariablesMixin):
                 notes=notes)
 
     def create_crunchbox(
-            self, title=None, header=None, footer=None, notes=None,
+            self, title='', header='', footer='', notes='',
             filters=None, variables=None, force=False, min_base_size=None,
             palette=None):
         """
@@ -2149,10 +2149,6 @@ class Dataset(ReadOnly, DatasetVariablesMixin):
                 header=header,
                 footer=footer)
         )
-
-        for field in ('title', 'header', 'footer', 'notes'):
-            if payload['body'].get(field) is None:
-                payload['body'][field] = ''
 
         if min_base_size:
             payload['body'].setdefault('display_settings', {}).update(

--- a/scrunch/datasets.py
+++ b/scrunch/datasets.py
@@ -2150,6 +2150,10 @@ class Dataset(ReadOnly, DatasetVariablesMixin):
                 footer=footer)
         )
 
+        for field in ('title', 'header', 'footer', 'notes'):
+            if payload['body'].get(field) is None:
+                payload['body'][field] = ''
+
         if min_base_size:
             payload['body'].setdefault('display_settings', {}).update(
                 dict(minBaseSize=dict(value=min_base_size)))

--- a/scrunch/datasets.py
+++ b/scrunch/datasets.py
@@ -2061,7 +2061,8 @@ class Dataset(ReadOnly, DatasetVariablesMixin):
 
     def create_crunchbox(
             self, title=None, header=None, footer=None, notes=None,
-            filters=None, variables=None, force=False):
+            filters=None, variables=None, force=False, min_base_size=None,
+            palette=None):
         """
         create a new boxdata entity for a CrunchBox.
 
@@ -2076,6 +2077,18 @@ class Dataset(ReadOnly, DatasetVariablesMixin):
             filters    (list): list of filter names or `Filter` instances
             where      (list): list of variable aliases or `Variable` instances
                                If `None` all variables will be included.
+            min_base_size (int): min sample size to display values in graph
+            palette     dict : dict of colors as documented at docs.crunch.io
+                i.e.
+                {
+                    "brand": ["#111111", "#222222", "#333333"],
+                    "static_colors": ["#444444", "#555555", "#666666"],
+                    "base": ["#777777", "#888888", "#999999"],
+                    "category_lookup": {
+                        "category name": "#aaaaaa",
+                        "another category:": "bbbbbb"
+                }
+
         Returns:
             CrunchBox (instance)
         """
@@ -2136,6 +2149,13 @@ class Dataset(ReadOnly, DatasetVariablesMixin):
                 header=header,
                 footer=footer)
         )
+
+        if min_base_size:
+            payload['body'].setdefault('display_settings', {}).update(
+                dict(minBaseSize=dict(value=min_base_size)))
+        if palette:
+            payload['body'].setdefault('display_settings', {}).update(
+                dict(palette=palette))
 
         # create the boxdata
         self.resource.boxdata.create(payload)

--- a/scrunch/tests/test_datasets.py
+++ b/scrunch/tests/test_datasets.py
@@ -206,6 +206,63 @@ class TestDatasets(TestDatasetBase, TestCase):
         assert ds.start_date == '2017-01-01'
         ds.resource._edit.assert_called_with(**changes)
 
+    def test_create_crunchbox_full(self):
+        ds_mock = self._dataset_mock()
+        ds = Dataset(ds_mock)
+
+        call_params = dict(
+            title='my title',
+            header='my header',
+            footer='my footer',
+            notes='my notes',
+            min_base_size=50,
+            palette={
+                "brand": ["#111111", "#222222", "#333333"],
+                "static_colors": ["#444444", "#555555", "#666666"],
+                "base": ["#777777", "#888888", "#999999"],
+            }
+        )
+
+        expected_payload = {
+            'element': 'shoji:entity',
+            'body': {
+                'header': 'my header',
+                'footer': 'my footer',
+                'title': 'my title',
+                'display_settings': {'palette': {
+                    'base': ['#777777', '#888888', '#999999'],
+                    'brand': ['#111111', '#222222', '#333333'],
+                    'static_colors': ['#444444', '#555555', '#666666']},
+                    'minBaseSize': {'value': 50}
+                },
+                'filters': None,
+                'notes': 'my notes',
+                'force': False,
+                'where': None}
+        }
+
+        ds.create_crunchbox(**call_params)
+        ds_mock.boxdata.create.assert_called_with(expected_payload)
+
+    def test_create_crunchbox_defaults(self):
+        ds_mock = self._dataset_mock()
+        ds = Dataset(ds_mock)
+
+        expected_payload = {
+            'element': 'shoji:entity',
+            'body': {
+                'header': '',
+                'footer': '',
+                'title': 'CrunchBox for test_dataset_name',
+                'filters': None,
+                'notes': '',
+                'force': False,
+                'where': None}
+        }
+
+        ds.create_crunchbox()
+        ds_mock.boxdata.create.assert_called_with(expected_payload)
+
 
 class TestExclusionFilters(TestDatasetBase, TestCase):
 


### PR DESCRIPTION
This PR adds support for `display_settings` like `minBaseSize` and a `palette` dict for configuring custom colors