### PR TITLE
added ds.create_numeric

### DIFF
--- a/scrunch/datasets.py
+++ b/scrunch/datasets.py
@@ -2041,6 +2041,33 @@ class Dataset(ReadOnly, DatasetVariablesMixin):
             return wait_progress(r=progress, session=self.resource.session, entity=self)
         return progress.json()['value']
 
+    def create_numeric(self, *, alias, name, derivation, description='', notes=''):
+        """
+        Used to create new numeric variables using Crunchs's derived expressions
+        """
+
+        expr = parse_expr(derivation)
+
+        if not hasattr(self.resource, 'variables'):
+            self.resource.refresh()
+
+        payload = dict(
+            element='shoji:entity',
+            body=dict(
+                alias=alias,
+                name=name,
+                derivation=expr,
+                description=description,
+                notes=notes
+            )
+        )
+
+        self.resource.variables.create(payload)
+        # needed to update the variables collection
+        self._reload_variables()
+        # return the variable instance
+        return self[alias]
+
     def create_categorical(self, categories, alias, name, multiple,
                            description='', notes=''):
         """

--- a/scrunch/datasets.py
+++ b/scrunch/datasets.py
@@ -2041,7 +2041,7 @@ class Dataset(ReadOnly, DatasetVariablesMixin):
             return wait_progress(r=progress, session=self.resource.session, entity=self)
         return progress.json()['value']
 
-    def create_numeric(self, *, alias, name, derivation, description='', notes=''):
+    def create_numeric(self, alias, name, derivation, description='', notes=''):
         """
         Used to create new numeric variables using Crunchs's derived expressions
         """

--- a/scrunch/expressions.py
+++ b/scrunch/expressions.py
@@ -195,6 +195,26 @@ def parse_expr(expr):
                 return {
                     'value': _val
                 }
+            elif isinstance(node, ast.Add):
+                return '+'
+            elif isinstance(node, ast.Sub):
+                return '-'
+            elif isinstance(node, ast.Mult):
+                return '*'
+            elif isinstance(node, ast.Div):
+                return '/'
+            elif isinstance(node, ast.FloorDiv):
+                return '//'
+            elif isinstance(node, ast.Pow):
+                return '^'
+            elif isinstance(node, ast.Mod):
+                return '%'
+            elif isinstance(node, ast.BitAnd):
+                return '&'
+            elif isinstance(node, ast.BitOr):
+                return '|'
+            elif isinstance(node, ast.Invert):
+                return '~'
             elif isinstance(node, ast.Eq):
                 return '=='
             elif isinstance(node, ast.NotEq):
@@ -339,6 +359,10 @@ def parse_expr(expr):
                     elif isinstance(_val, list):
                         for arg in _val:
                             args.append(_parse(arg, parent=node))
+                    elif isinstance(_val, ast.BinOp):
+                        op = _parse(_val.op, _val)
+                        args.append(_parse(_val.left, _val))
+                        args.append(_parse(_val.right, _val))
 
                 if op:
                     if op is NOT_IN:

--- a/scrunch/tests/test_datasets.py
+++ b/scrunch/tests/test_datasets.py
@@ -206,6 +206,54 @@ class TestDatasets(TestDatasetBase, TestCase):
         assert ds.start_date == '2017-01-01'
         ds.resource._edit.assert_called_with(**changes)
 
+    def test_create_numeric(self):
+        variables = {
+            '001': {
+                'id': '001',
+                'alias': 'weekly_rent',
+                'name': 'Week rent',
+                'type': 'numeric',
+                'is_subvar': False
+            },
+        }
+        ds_mock = self._dataset_mock(variables=variables)
+        ds = Dataset(ds_mock)
+
+        ds.resource = mock.MagicMock()
+
+        ds.create_numeric(
+            alias='monthly_rent',
+            name='Monthly rent',
+            description='Rent paid per month',
+            notes='All UK adults',
+            derivation='(weekly_rent * 52) / 12'
+        )
+
+        ds.resource.variables.create.assert_called_with(
+            {
+                'element': 'shoji:entity',
+                'body': {
+                    'alias': 'monthly_rent',
+                    'name': 'Monthly rent',
+                    'derivation': {
+                        'function': '/',
+                        'args': [
+                            {
+                                'function': '*',
+                                'args': [
+                                    {'variable': 'weekly_rent'},
+                                    {'value': 52}
+                                ]
+                            },
+                            {'value': 12}
+                        ]
+                    },
+                    'description': 'Rent paid per month',
+                    'notes': 'All UK adults'
+                }
+            }
+        )
+
 
 class TestExclusionFilters(TestDatasetBase, TestCase):
 

--- a/scrunch/tests/test_expressions.py
+++ b/scrunch/tests/test_expressions.py
@@ -1034,6 +1034,47 @@ class TestExpressionParsing(TestCase):
         expr_obj = parse_expr(expr)
         assert expr_obj == expected
 
+    def test_multiple_arithmetic_operations(self):
+        expr =  "1 * 2 + 3"
+        expr_obj = parse_expr(expr)
+
+        assert expr_obj == {
+            'function': '+', 'args': [
+                {
+                    'function': '*',
+                    'args': [
+                        {'value': 1},
+                        {'value': 2}
+                    ]
+                },
+                {'value': 3}
+            ]
+        }
+
+    def test_multiple_arithmetic_operations_with_variable(self):
+        expr = "(weekly_rent * 52) + 12"
+        expr_obj = parse_expr(expr)
+
+        assert expr_obj == {
+            "function": "+",
+            "args": [
+                {
+                    "function": "*",
+                    "args": [
+                        {
+                            "variable": "weekly_rent"
+                        },
+                        {
+                            "value": 52
+                        }
+                    ]
+                },
+                {
+                    "value": 12
+                }
+            ]
+        }
+
     def test_parse_helper_functions(self):
         # One variable.
         expr = "valid(birthyear)"


### PR DESCRIPTION
Added the method as described in #111, except that the _filter_ parameter is not included and _expressions_ has was renamed to _derivation_. Sample usage: 

```python

ds.create_numeric(
            alias='monthly_rent',
            name='Monthly rent',
            description='Rent paid per month',
            notes='All UK adults',
            derivation='(weekly_rent * 52) / 12'
        )
```