### PR TITLE
Added timeout control to Dataset.export

### DIFF
--- a/scrunch/datasets.py
+++ b/scrunch/datasets.py
@@ -1865,7 +1865,7 @@ class Dataset(ReadOnly, DatasetVariablesMixin):
             fork.entity.delete()
 
     def export(self, path, format='csv', filter=None, variables=None,
-               hidden=False, options=None, metadata_path=None):
+               hidden=False, options=None, metadata_path=None, timeout=None):
         """
         Downloads a dataset as CSV or as SPSS to the given path. This
         includes hidden variables.
@@ -1985,7 +1985,13 @@ class Dataset(ReadOnly, DatasetVariablesMixin):
                 }]
             }
 
-        url = export_dataset(self.resource, payload, format=format)
+        progress_tracker = pycrunch.progress.DefaultProgressTracking(timeout)
+        url = export_dataset(
+            dataset=self.resource,
+            options=payload, 
+            format=format, 
+            progress_tracker=progress_tracker
+        )
         download_file(url, path)
 
     def join(self, left_var, right_ds, right_var, columns=None,

--- a/scrunch/tests/test_datasets.py
+++ b/scrunch/tests/test_datasets.py
@@ -3501,12 +3501,14 @@ class TestDatasetExport(TestCase):
 
         ds.export('export.csv')
 
-        export_payload = export_ds_mock.call_args_list[0][0][1]
         export_format = export_ds_mock.call_args_list[0][1].get('format')
-        export_options = export_payload.get('options', {})
+        export_options = export_ds_mock.call_args_list[0][1].get('options', {})
 
         assert export_format == 'csv'
-        assert export_options == {'use_category_ids': True}
+        assert export_options == {
+            'options': {
+                'use_category_ids': True
+            }}
 
         dl_file_mock.assert_called_with(self.file_download_url, 'export.csv')
 
@@ -3523,12 +3525,14 @@ class TestDatasetExport(TestCase):
 
         ds.export('export.csv', options={'use_category_ids': False})
 
-        export_payload = export_ds_mock.call_args_list[0][0][1]
         export_format = export_ds_mock.call_args_list[0][1].get('format')
-        export_options = export_payload.get('options', {})
+        export_options = export_ds_mock.call_args_list[0][1].get('options', {})
 
         assert export_format == 'csv'
-        assert export_options == {'use_category_ids': False}
+        assert export_options == {
+            'options': {
+                'use_category_ids': False
+            }}
 
         dl_file_mock.assert_called_with(self.file_download_url, 'export.csv')
 
@@ -3545,15 +3549,15 @@ class TestDatasetExport(TestCase):
 
         ds.export('export.sav', format='spss')
 
-        export_payload = export_ds_mock.call_args_list[0][0][1]
         export_format = export_ds_mock.call_args_list[0][1].get('format')
-        export_options = export_payload.get('options', {})
+        export_options = export_ds_mock.call_args_list[0][1].get('options', {})
 
         assert export_format == 'spss'
         assert export_options == {
-            'prefix_subvariables': False,
-            'var_label_field': 'description'
-        }
+            'options': {
+                'prefix_subvariables': False,
+                'var_label_field': 'description'
+            }}
 
         dl_file_mock.assert_called_with(self.file_download_url, 'export.sav')
 
@@ -3570,14 +3574,15 @@ class TestDatasetExport(TestCase):
             }
         )
 
-        export_payload = export_ds_mock.call_args_list[0][0][1]
         export_format = export_ds_mock.call_args_list[0][1].get('format')
-        export_options = export_payload.get('options', {})
+        export_options = export_ds_mock.call_args_list[0][1].get('options', {})
 
         assert export_format == 'spss'
         assert export_options == {
-            'prefix_subvariables': True,
-            'var_label_field': 'name'}
+            'options': {
+                'var_label_field': 'name',
+                'prefix_subvariables': True
+        }}
 
         dl_file_mock.assert_called_with(self.file_download_url, 'export.sav')
 


### PR DESCRIPTION
Added a `timeout` arg to `Dataset.export()`, which is used to construct a custom `progress_tracker` to help minimize `TaskProgressTimeoutErrors`. This will default to `None` meaning there is no timeout.