### PR TITLE
only check for reasonable words with optional whitespace prepended.

### DIFF
--- a/scrunch/datasets.py
+++ b/scrunch/datasets.py
@@ -487,7 +487,7 @@ class Group(object):
             raise ValueError(
                 'The pipe (|) character is not allowed.'
             )
-        if not re.match(r'^[\w\s]+$', name, re.UNICODE):
+        if not re.match(r'^(\s+)?\w+', name, re.UNICODE):
             raise ValueError(
                 'Invalid name %s: it contains characters that are not allowed.'
                 % name

--- a/scrunch/tests/test_datasets.py
+++ b/scrunch/tests/test_datasets.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 import collections
 import json
 import copy
@@ -3061,6 +3063,48 @@ class TestHierarchicalOrder(TestCase):
 
         with pytest.raises(ValueError):
             ds.order['|Account'].create_group('@##$')
+
+        ds.order['|Account'].create_group('Gewürze / Inhaltsstoffe', alias=[
+            'music', 'religion'])
+
+        assert self._get_update_payload(ds) == {
+            'element': 'shoji:order',
+            'graph': [
+                '../000001/',
+                '../000002/',
+                {
+                    'Account': [
+                        {
+                            'User Information': [
+                                '../000005/',
+                                '../000006/',
+                                '../000007/'
+                            ]
+                        },
+                        {
+                            'Location': [
+                                '../000008/',
+                                '../000009/',
+                                '../000010/',
+                                '../000011/'
+                            ]
+                        },
+                        {
+                            'Login Details': [
+                                '../000003/',
+                                '../000004/'
+                            ]
+                        },
+                        {
+                            'Gewürze / Inhaltsstoffe': [
+                                '../000012/',
+                                '../000013/'
+                            ]
+                        }
+                    ]
+                }
+            ]
+        }
 
     def test_group_renaming(self):
         ds = self.ds


### PR DESCRIPTION
fixes #131

although I first thought to remove it completely the test which failed when removing the `$` made actually sense. So I now opted for just checking if the first word is reasonable.

