### PR TITLE
support `before` and `after` in the Variable.move method

### DIFF
--- a/scrunch/datasets.py
+++ b/scrunch/datasets.py
@@ -2555,11 +2555,14 @@ class Variable(ReadOnly, DatasetSubvariablesMixin):
     def edit_derived(self, variable, mapper):
         raise NotImplementedError("Use edit_combination")
 
-    def move(self, path, position=-1):
+    def move(self, path, position=-1, before=None, after=None):
+        position = 0 if (before or after) else position
         path = Path(path)
         if not path.is_absolute:
             raise InvalidPathError(
                 'Invalid path %s: only absolute paths are allowed.' % path
             )
         target_group = self.dataset.order[str(path)]
-        target_group.insert(self.alias, position=position)
+        target_group.insert(
+            self.alias, position=position, before=before, after=after
+        )

--- a/scrunch/tests/test_datasets.py
+++ b/scrunch/tests/test_datasets.py
@@ -3241,6 +3241,70 @@ class TestHierarchicalOrder(TestCase):
         with pytest.raises(scrunch.exceptions.InvalidPathError):
             var.move('|Account|Invalid Group')
 
+        var.move('|Account', before='registration_time')
+        assert self._get_update_payload(var.dataset) == {
+            'element': 'shoji:order',
+            'graph': [
+                '../000002/',                       # hobbies
+                {
+                    'Account': [
+                        '../000001/',               # id
+                        '../000003/',               # registration_time
+                        '../000004/',               # last_login_time
+                        {
+                            'User Information': [
+                                '../000005/',       # first_name
+                                '../000006/',       # last_name
+                                '../000007/',       # gender
+                            ]
+                        },
+                        {
+                            'Location': [
+                                '../000008/',       # country
+                                '../000009/',       # city
+                                '../000010/',       # zip_code
+                                '../000011/'        # address
+                            ]
+                        }
+                    ]
+                },
+                '../000012/',                       # music
+                '../000013/'                        # religion
+            ]
+        }
+
+        var.move('|', after='music')
+        assert self._get_update_payload(var.dataset) == {
+            'element': 'shoji:order',
+            'graph': [
+                '../000002/',                       # hobbies
+                {
+                    'Account': [
+                        '../000003/',               # registration_time
+                        '../000004/',               # last_login_time
+                        {
+                            'User Information': [
+                                '../000005/',       # first_name
+                                '../000006/',       # last_name
+                                '../000007/',       # gender
+                            ]
+                        },
+                        {
+                            'Location': [
+                                '../000008/',       # country
+                                '../000009/',       # city
+                                '../000010/',       # zip_code
+                                '../000011/'        # address
+                            ]
+                        }
+                    ]
+                },
+                '../000012/',                       # music
+                '../000001/',                       # id
+                '../000013/'                        # religion
+            ]
+        }
+
     def test_order_synchronization(self):
         ds = self.ds
 


### PR DESCRIPTION
fixes #135 