### PR TITLE
Supporting delete of Groups with a dict-like behaviour del group-path

### DIFF
--- a/scrunch/order.py
+++ b/scrunch/order.py
@@ -167,7 +167,6 @@ class Group(object):
         return item in self.elements and isinstance(self.elements[item], Group)
 
     def __delitem__(self, item):
-        print(self.elements[item].keys())
         if len(self.elements[item].keys()) == 0:
             del self.elements[item]
             self.order.update()

--- a/scrunch/order.py
+++ b/scrunch/order.py
@@ -166,6 +166,16 @@ class Group(object):
     def __contains__(self, item):
         return item in self.elements and isinstance(self.elements[item], Group)
 
+    def __delitem__(self, item):
+        print(self.elements[item].keys())
+        if len(self.elements[item].keys()) == 0:
+            del self.elements[item]
+            self.order.update()
+        else:
+            raise ValueError(
+                "Cannot delete Groups containing items. Group must be empty first"
+            )
+
     @property
     def is_root(self):
         return self.parent is None and self.name == '__root__'


### PR DESCRIPTION
this supposes deletes are in the form:

`del ds.order['GroupA']['GroupB']` where GroupB is an empty group, otherwise it will raise a ValueError.