### PR TITLE
Filter name encoding error

### DIFF
--- a/scrunch/categories.py
+++ b/scrunch/categories.py
@@ -1,4 +1,5 @@
 from collections import OrderedDict
+
 from six import PY2
 
 from scrunch.helpers import ReadOnly

--- a/scrunch/categories.py
+++ b/scrunch/categories.py
@@ -1,4 +1,5 @@
 from collections import OrderedDict
+from six import PY2
 
 from scrunch.helpers import ReadOnly
 
@@ -29,6 +30,8 @@ class Category(ReadOnly):
 
     def as_dict(self, **kwargs):
         dct = {attr: getattr(self, attr) for attr in self._ENTITY_ATTRIBUTES}
+        if PY2:
+            dct['name'] = dct['name'].encode("ascii", "replace")
         dct.update(**kwargs or {})
         return dct
 

--- a/scrunch/subentity.py
+++ b/scrunch/subentity.py
@@ -4,9 +4,9 @@ import json
 from pycrunch.lemonpy import URL
 from pycrunch.progress import DefaultProgressTracking
 from pycrunch.shoji import wait_progress
+from six import PY2
 
 import six.moves.urllib as urllib
-from six import PY2
 from scrunch.helpers import download_file
 
 

--- a/scrunch/subentity.py
+++ b/scrunch/subentity.py
@@ -6,6 +6,7 @@ from pycrunch.progress import DefaultProgressTracking
 from pycrunch.shoji import wait_progress
 
 import six.moves.urllib as urllib
+from six import PY2
 from scrunch.helpers import download_file
 
 
@@ -28,8 +29,12 @@ class SubEntity:
             '{} has no attribute {}'.format(self.__class__.__name__, item))
 
     def __repr__(self):
-        return "<{}: name='{}'; id='{}'>".format(
-            self.__class__.__name__, self.name, self.id)
+        if PY2:
+            name = self.name.encode("ascii", "replace")
+        else:
+            name = self.name
+        return u"<{}: name='{}'; id='{}'>".format(
+            self.__class__.__name__, name, self.id)
 
     def __str__(self):
         return self.__repr__()


### PR DESCRIPTION
Fix for:
https://github.com/Crunch-io/scrunch/issues/133

We don't get an encoding error anymore. But the naming is still not optimal.

Output look like this now:
{u'm\xe4nnlich': <Filter: name='m?nnlich'; id='5b1fb7db05d048998d353f3f9deda8d1'>, u'gender filter': <Filter: name='gender filter'; id='b08e5f73c8ab4e0ba4536d2515600ee6'>}

Obejct name can't be anything but ascii it seems in python 2:
https://bugs.python.org/issue5876#msg195996