### PR TITLE
[OrderAPI] project order requires two reloads when a dataset was added

### DIFF
--- a/scrunch/mutable_dataset.py
+++ b/scrunch/mutable_dataset.py
@@ -1,6 +1,7 @@
 import json
 
 from pycrunch.shoji import wait_progress
+
 from scrunch.datasets import LOG, BaseDataset, _get_connection, _get_dataset
 from scrunch.exceptions import (InvalidDatasetTypeError, InvalidParamError,
                                 InvalidVariableTypeError)

--- a/scrunch/mutable_dataset.py
+++ b/scrunch/mutable_dataset.py
@@ -1,8 +1,7 @@
 import json
 
 from pycrunch.shoji import wait_progress
-
-from scrunch.datasets import BaseDataset, _get_connection, _get_dataset, LOG
+from scrunch.datasets import LOG, BaseDataset, _get_connection, _get_dataset
 from scrunch.exceptions import (InvalidDatasetTypeError, InvalidParamError,
                                 InvalidVariableTypeError)
 from scrunch.expressions import parse_expr, process_expr

--- a/scrunch/mutable_dataset.py
+++ b/scrunch/mutable_dataset.py
@@ -197,7 +197,7 @@ class MutableDataset(BaseDataset):
         return diff
 
     def append_dataset(self, dataset, filter=None, variables=None,
-        autorollback=True, delete_pk=True):
+                       autorollback=True, delete_pk=True):
         """ Append dataset into self. If this operation fails, the
         append is rolledback. Dataset variables and subvariables
         are matched on their aliases and categories are matched by name.

--- a/scrunch/order.py
+++ b/scrunch/order.py
@@ -82,8 +82,8 @@ class Group(object):
                     if dataset:
                         self.elements[dataset.id] = dataset
                     else:
-                        for key, obj in self.order.catalog.refresh()[
-                                                            'index'].items():
+                        refresh_ds = self.order.catalog.refresh()['index']
+                        for key, obj in refresh_ds.items():
                             if _id in key:
                                 self.elements[obj.id] = obj
                                 break

--- a/scrunch/order.py
+++ b/scrunch/order.py
@@ -81,6 +81,12 @@ class Group(object):
                     dataset = self.order.datasets.get(_id)
                     if dataset:
                         self.elements[dataset.id] = dataset
+                    else:
+                        for key, obj in self.order.catalog.refresh()[
+                                                            'index'].items():
+                            if _id in key:
+                                self.elements[obj.id] = obj
+                                break
             elif isinstance(element, dict):
                 subgroup = Group(element, order=self.order, parent=self)
                 self.elements[subgroup.name] = subgroup


### PR DESCRIPTION
Fixes https://github.com/Crunch-io/scrunch/issues/161