### PR TITLE
adding edit_resolution method to support changing rollup_resolution of a datetime variable

### DIFF
--- a/scrunch/datasets.py
+++ b/scrunch/datasets.py
@@ -2157,7 +2157,7 @@ class Variable(ReadOnly, DatasetSubvariablesMixin):
     A pycrunch.shoji.Entity wrapper that provides variable-specific methods.
     DatasetSubvariablesMixin provides for subvariable interactions.
     """
-    _MUTABLE_ATTRIBUTES = {'name', 'description',
+    _MUTABLE_ATTRIBUTES = {'name', 'description', 'rollup_resolution',
                            'view', 'notes', 'format', 'derived'}
     _IMMUTABLE_ATTRIBUTES = {'id', 'alias', 'type', 'discarded'}
     # We won't expose owner and private
@@ -2502,7 +2502,5 @@ class Variable(ReadOnly, DatasetSubvariablesMixin):
         assert self.type == 'datetime', 'Method only allowed for datetime variables'
         self.dataset._validate_vartypes(self.type, resolution=resolution)
 
-        payload = json.dumps({'rollup_resolution': resolution})
-        resp = self.resource.patch(payload)
-        self.dataset._reload_variables()
-        return self.dataset[self.alias]
+        self.resource.edit(rollup_resolution=resolution)
+        return self

--- a/scrunch/datasets.py
+++ b/scrunch/datasets.py
@@ -2157,7 +2157,7 @@ class Variable(ReadOnly, DatasetSubvariablesMixin):
     A pycrunch.shoji.Entity wrapper that provides variable-specific methods.
     DatasetSubvariablesMixin provides for subvariable interactions.
     """
-    _MUTABLE_ATTRIBUTES = {'name', 'description', 'rollup_resolution',
+    _MUTABLE_ATTRIBUTES = {'name', 'description',
                            'view', 'notes', 'format', 'derived'}
     _IMMUTABLE_ATTRIBUTES = {'id', 'alias', 'type', 'discarded'}
     # We won't expose owner and private
@@ -2494,13 +2494,17 @@ class Variable(ReadOnly, DatasetSubvariablesMixin):
             return self.view.transform.insertions
         return None
 
-    def rollup_resolution(self, resolution):
+    def edit_resolution(self, resolution):
         """
         PATCHes the rollup_resolution attribute of a datetime variable. This is the
-        equivalent to the UI's change resolution action.
+        equivalent to the UI's change resolution action. 
+
+        Be sure to grab the editor's lock of the dataset.
+        
+        :usage: edited_var = var.edit_resolution('M')
+        assert editar_var.rollup_resolution == 'M'
         """
         assert self.type == 'datetime', 'Method only allowed for datetime variables'
         self.dataset._validate_vartypes(self.type, resolution=resolution)
-
-        self.resource.edit(rollup_resolution=resolution)
+        self.resource.edit(view=dict(rollup_resolution=resolution))
         return self

--- a/scrunch/expressions.py
+++ b/scrunch/expressions.py
@@ -476,8 +476,11 @@ def process_expr(obj, ds):
         """
         # convert value --> column and change ids to aliases
         aliases = get_subvariables_resource(var_url)
+
+        # Some derived variables will append a # to the subvariables id's
+        # so we need to strip those charactes out
         cat_to_ids = [
-            tup[0] for tup in aliases if int(tup[1].split('_')[-1]) in values]
+            tup[0] for tup in aliases if int(tup[1].strip('#').split('_')[-1]) in values]
         return [{'variable': var_url}, {'column': cat_to_ids}], False
 
     def ensure_category_ids(subitems, variables=variables):


### PR DESCRIPTION
This method is still not working, but I can't figure why. I am sending the data just like the UI is. 