### PR TITLE
Feature/267 crunch teams

### DIFF
--- a/scrunch/__init__.py
+++ b/scrunch/__init__.py
@@ -1,12 +1,13 @@
 from .session import connect
-from .datasets import get_user, get_project, get_dataset
+from .datasets import (
+    get_user, get_project, get_dataset, get_team, create_team)
 from .streaming_dataset import get_streaming_dataset
 from .mutable_dataset import get_mutable_dataset, create_dataset
 from .version import __version__
 
 
 __all__ = [
-    'connect', 'get_user', 'get_project', 'get_dataset',
-    'get_streaming_dataset', 'get_mutable_dataset',
+    'connect', 'get_user', 'get_project', 'get_dataset', 'get_team',
+    'get_streaming_dataset', 'get_mutable_dataset', 'create_team',
     'create_dataset', '__version__'
 ]


### PR DESCRIPTION
This is a non-backward compatible change, since it will be removing methods from the Project class and moving them to a generic approach `add_member`, `remove_member`, `members` that will work equally with Teams or Projects.

This is still a work in progress because it will need tests and I am seeking design approval first.