### PR TITLE
pandas must be an optional requirement 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,4 +33,6 @@ cache: pip
 install:
 - pip install tox tox-venv
 
-script: tox
+script:
+  - tox
+  - tox -e pandas

--- a/scrunch/datasets.py
+++ b/scrunch/datasets.py
@@ -6,7 +6,13 @@ import os
 import re
 import sys
 
-import pandas as pd
+try:
+    import pandas as pd
+except ImportError:
+    # pandas has not been installed, don't worry!
+    # ... unless you have to worry about pandas
+    pd = None
+
 import six
 
 import pycrunch
@@ -2013,6 +2019,8 @@ class BaseDataset(ReadOnly, DatasetVariablesMixin):
             A DataFrame representation of all attributes from all forks
             on the given dataset.
         """
+        if pd is None:
+            raise ModuleNotFoundError("No module named 'pandas'")
 
         if len(self.resource.forks.index) == 0:
             return None

--- a/scrunch/datasets.py
+++ b/scrunch/datasets.py
@@ -2020,7 +2020,10 @@ class BaseDataset(ReadOnly, DatasetVariablesMixin):
             on the given dataset.
         """
         if pd is None:
-            raise ModuleNotFoundError("No module named 'pandas'")
+            raise ModuleNotFoundError(
+                "Pandas is not installed, please install it in your "
+                "environment to use this function."
+            )
 
         if len(self.resource.forks.index) == 0:
             return None

--- a/scrunch/datasets.py
+++ b/scrunch/datasets.py
@@ -2034,7 +2034,7 @@ class BaseDataset(ReadOnly, DatasetVariablesMixin):
             on the given dataset.
         """
         if pd is None:
-            raise ModuleNotFoundError(
+            raise ImportError(
                 "Pandas is not installed, please install it in your "
                 "environment to use this function."
             )

--- a/scrunch/datasets.py
+++ b/scrunch/datasets.py
@@ -2041,7 +2041,7 @@ class BaseDataset(ReadOnly, DatasetVariablesMixin):
             _forks['creation_time'] = pd.to_datetime(_forks['creation_time'])
             _forks['modification_time'] = pd.to_datetime(
                 _forks['modification_time'])
-            _forks.sort(columns='creation_time', inplace=True)
+            _forks.sort_values(by=['creation_time'], inplace=True)
 
             return _forks
 

--- a/scrunch/tests/integration/scrunch_workflow_integration_test.py
+++ b/scrunch/tests/integration/scrunch_workflow_integration_test.py
@@ -5,7 +5,9 @@ import os
 
 import isodate
 import pycrunch
-from pycrunch import pandaslib
+import pytest
+
+pytest.mark.skip('skip test discovery on this module')
 
 from scrunch import connect
 from scrunch.datasets import Variable, get_geodata

--- a/scrunch/tests/test_datasets.py
+++ b/scrunch/tests/test_datasets.py
@@ -1618,7 +1618,7 @@ class TestForks(TestCase):
         ds_res.forks.index = {}
 
         ds = BaseDataset(ds_res)
-        with pytest.raises(ModuleNotFoundError) as err:
+        with pytest.raises(ImportError) as err:
             ds.forks_dataframe()
 
     def test_merge_fork(self):

--- a/scrunch/tests/test_datasets.py
+++ b/scrunch/tests/test_datasets.py
@@ -6,10 +6,17 @@ import copy
 
 import mock
 from mock import MagicMock
+
+try:
+    import pandas
+    from pandas import DataFrame
+except:
+    # pandas is not installed
+    pandas = None
+
 from unittest import TestCase
 
 import pytest
-from pandas import DataFrame
 from pycrunch.elements import JSONObject, ElementSession
 from pycrunch.variables import cast
 
@@ -1560,6 +1567,8 @@ class TestForks(TestCase):
         assert f2.entity.delete.call_count == 1
         assert f3.entity.delete.call_count == 1
 
+    @pytest.mark.skipif(pandas is None,
+                        reason='pandas is not installed')
     def test_forks_dataframe(self):
         f1 = dict(
             name='name',
@@ -1587,6 +1596,8 @@ class TestForks(TestCase):
             'current_editor_name', 'creation_time', 'modification_time', 'id'
         ]
 
+    @pytest.mark.skipif(pandas is None,
+                        reason='pandas is not installed')
     def test_forks_dataframe_empty(self):
         sess = MagicMock()
         ds_res = MagicMock(session=sess)
@@ -1597,6 +1608,18 @@ class TestForks(TestCase):
         df = ds.forks_dataframe()
 
         assert df is None
+
+    @pytest.mark.skipif(pandas is not None,
+                        reason='pandas is installed')
+    def test_forks_no_pandas(self):
+        sess = MagicMock()
+        ds_res = MagicMock(session=sess)
+        ds_res.forks = MagicMock()
+        ds_res.forks.index = {}
+
+        ds = BaseDataset(ds_res)
+        with pytest.raises(ModuleNotFoundError) as err:
+            ds.forks_dataframe()
 
     def test_merge_fork(self):
         fork1_url = 'http://test.crunch.io/api/datasets/abc/'

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ params = dict(
 
             # local
         ],
-        'pandas': ['pandas<0.20'],
+        'pandas': ['pandas'],
     },
     setup_requires=[
         'setuptools_scm>=1.15.0',

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,6 @@ params = dict(
     ),
     python_requires='>=2.7',
     install_requires=[
-        'pandas<0.20',
         'pycrunch>=0.4.8',
         'requests',
         'six',
@@ -60,7 +59,7 @@ params = dict(
 
             # local
         ],
-        'pandas': ['pandas'],
+        'pandas': ['pandas<0.20'],
     },
     setup_requires=[
         'setuptools_scm>=1.15.0',

--- a/tox.ini
+++ b/tox.ini
@@ -14,6 +14,19 @@ commands =
 usedevelop = True
 extras =
     testing
+
+[testenv:pandas]
+deps =
+	setuptools>=31.0.1
+	# workaround for yaml/pyyaml#126
+	# git+https://github.com/yaml/pyyaml@master#egg=pyyaml;python_version=="3.7"
+   git+https://github.com/Crunch-io/pycrunch#pycrunch
+commands =
+    py.test {posargs}
+    python setup.py checkdocs
+usedevelop = True
+extras =
+    testing
     pandas
 
 [testenv:build-docs]

--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,9 @@ commands =
     py.test {posargs}
     python setup.py checkdocs
 usedevelop = True
-extras = testing
+extras =
+    testing
+    pandas
 
 [testenv:build-docs]
 extras =


### PR DESCRIPTION
pandas must be an optional requirement as no all applications that uses scrunch needs pandas.

Also pandas requires numpy and having both wastes unnecessary resources when building an environment from scratch.

As soon as this is merged I'll add the corresponding instructions to the wiki for the people needing pandas.