### PR TITLE
Expose the dataset's size object as a property of the dataset instance

### DIFF
--- a/scrunch/datasets.py
+++ b/scrunch/datasets.py
@@ -2514,6 +2514,13 @@ class BaseDataset(ReadOnly, DatasetVariablesMixin):
         }
         self.resource.table.post(json.dumps(payload))
 
+    @property
+    def size(self):
+        """
+        Exposes the dataset's size object as a property of the dataset instance
+        """
+        return self.resource.body.size
+
 
 class Dataset(BaseDataset):
 


### PR DESCRIPTION
So we (as scrunch users) are able to do:
```python
>>> dataset.size.columns
... 99
```

instead of:
```python
>>> dataset.resource.body.size.columns
... 99
```