### PR TITLE
Warsaw demo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,3 +99,5 @@ crunch.ini
 # Pycharm/Idea
 .idea/
 
+# Vim
+*.swp

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,4 @@
 [pytest]
 norecursedirs=dist build .tox .eggs
-addopts=--doctest-modules --cov=scrunch --cov-config=.coveragerc
+addopts=--doctest-modules --cov=scrunch --cov-config=.coveragerc -p no:sugar
 doctest_optionflags=ALLOW_UNICODE ELLIPSIS

--- a/scrunch/cubes.py
+++ b/scrunch/cubes.py
@@ -1,0 +1,12 @@
+from pycrunch.cubes import fetch_cube, count
+from cr.cube.crunch_cube import CrunchCube
+
+
+def crtabs(dataset, variables):
+    """Return CrunchCube representation of crosstab.
+
+    :param dataset: Dataset shoji object
+    :param variables: List of variable urls, names or aliases
+    """
+    dataset = dataset.resource
+    return CrunchCube(fetch_cube(dataset, variables, count=count()))

--- a/scrunch/cubes.py
+++ b/scrunch/cubes.py
@@ -1,4 +1,5 @@
 from pycrunch.cubes import fetch_cube, count
+from scrunch.datasets import Variable
 from cr.cube.crunch_cube import CrunchCube
 
 
@@ -9,4 +10,12 @@ def crtabs(dataset, variables):
     :param variables: List of variable urls, names or aliases
     """
     dataset = dataset.resource
+    variables = prepare_variables(variables)
     return CrunchCube(fetch_cube(dataset, variables, count=count()))
+
+
+def prepare_variables(variables):
+    return [
+        v.url if type(v) is Variable else v
+        for v in variables
+    ]

--- a/scrunch/tests/test_cubes.py
+++ b/scrunch/tests/test_cubes.py
@@ -1,0 +1,40 @@
+import pytest
+from mock import patch, MagicMock
+from pycrunch.cubes import fetch_cube, count
+from scrunch.cubes import crtabs, prepare_variables
+from scrunch.datasets import Variable
+
+
+def test_prepare_variables(variables_fixture):
+    """Test if urls are extracted from variables."""
+    urls, variables = variables_fixture
+    assert prepare_variables(variables) == urls
+
+
+@patch('scrunch.cubes.fetch_cube')
+def test_crtabs_passes_string_arguments(mock_fetch_cube, variables_fixture):
+    """Test if url strings are passed to fetch_cube."""
+    fake_ds = MagicMock(resource=MagicMock())
+    mock_fetch_cube.return_value = {'result': {}}
+    urls, _ = variables_fixture
+    crtabs(fake_ds, urls)
+    mock_fetch_cube.assert_called_once_with(fake_ds.resource, urls, count=count())
+
+
+@patch('scrunch.cubes.fetch_cube')
+def test_crtabs_passes_urls_for_variables(mock_fetch_cube, variables_fixture):
+    """Test if urls are from variables are passed to fetch_cube."""
+    fake_ds = MagicMock(resource=MagicMock())
+    mock_fetch_cube.return_value = {'result': {}}
+    urls, variables = variables_fixture
+    crtabs(fake_ds, variables)
+    mock_fetch_cube.assert_called_once_with(fake_ds.resource, urls, count=count())
+
+
+@pytest.fixture(params=[
+    ['fake url 1', 'fake url 2']
+])
+def variables_fixture(request):
+    urls = request.param
+    variables = [Variable(MagicMock(entity_url=url), MagicMock()) for url in urls]
+    return urls, variables

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ params = dict(
         'pycrunch>=0.4.8',
         'requests',
         'six',
+        'cr.cube',
     ],
     extras_require={
         'testing': [


### PR DESCRIPTION
- Implement `crtabs` - a method for seamless fetching of crunch cubes
- Add `cr.cube` dependency
- Needs [this pycrunch PR](https://github.com/Crunch-io/pycrunch/pull/54) to work properly
- Needs [this cr.cube PR](https://github.com/Crunch-io/crunch-cube/pull/105) to display cubes in console nicely