### PR TITLE
Improve `_get_dataset(…)` function so it makes less requests to crunch

### DIFF
--- a/scrunch/helpers.py
+++ b/scrunch/helpers.py
@@ -181,15 +181,3 @@ def shoji_catalog_wrapper(index, **kwargs):
     }
     payload.update(**kwargs)
     return payload
-
-
-def validate_uuid(ref):
-    """
-    Check if given string is a valid uuid.
-    """
-    try:
-        uuid.UUID(ref)
-    except ValueError:
-        return False
-    else:
-        return True

--- a/scrunch/helpers.py
+++ b/scrunch/helpers.py
@@ -1,6 +1,5 @@
 import requests
 import six
-import uuid
 
 if six.PY2:  # pragma: no cover
     from urlparse import urljoin

--- a/scrunch/helpers.py
+++ b/scrunch/helpers.py
@@ -1,5 +1,6 @@
 import requests
 import six
+import uuid
 
 if six.PY2:  # pragma: no cover
     from urlparse import urljoin
@@ -180,3 +181,15 @@ def shoji_catalog_wrapper(index, **kwargs):
     }
     payload.update(**kwargs)
     return payload
+
+
+def validate_uuid(ref):
+    """
+    Check if given string is a valid uuid.
+    """
+    try:
+        uuid.UUID(ref)
+    except ValueError:
+        return False
+    else:
+        return True

--- a/scrunch/tests/test_utilities.py
+++ b/scrunch/tests/test_utilities.py
@@ -124,10 +124,11 @@ class TestUtilities(object):
 
     @mock.patch('pycrunch.session')
     def test_get_dataset_from_project_no_name(self, session):
+        dataset_id = 'b2c4c6b7d3a94e58937b23c1fed1b65e'
         shoji_entity = {
             'element': 'shoji:entity',
             'body': {
-                'id': 'b2c4c6b7d3a94e58937b23c1fed1b65e',
+                'id': dataset_id,
                 'name': 'dataset_name',
                 'streaming': 'no'
             }
@@ -146,12 +147,12 @@ class TestUtilities(object):
         session.session.get.side_effect = _get
         session.catalogs.datasets = 'https://test.crunch.io/api/'
 
-        ds = get_mutable_dataset('b2c4c6b7d3a94e58937b23c1fed1b65e')
+        ds = get_mutable_dataset(dataset_id)
         session.session.get.assert_called_with('https://test.crunch.io/api/b2c4c6b7d3a94e58937b23c1fed1b65e/')
 
         assert isinstance(ds, MutableDataset)
         assert ds.name == 'dataset_name'
-        assert ds.id == 'b2c4c6b7d3a94e58937b23c1fed1b65e'
+        assert ds.id == dataset_id
 
     @mock.patch('pycrunch.session')
     def test_get_project(self, session):

--- a/scrunch/tests/test_utilities.py
+++ b/scrunch/tests/test_utilities.py
@@ -4,6 +4,7 @@ import pytest
 import mock
 
 import scrunch
+from scrunch.helpers import validate_uuid
 from scrunch.variables import validate_variable_url
 from scrunch import get_project, get_mutable_dataset, get_user
 from scrunch.datasets import Project, User
@@ -54,6 +55,14 @@ def test_variable_url_validation():
         '/variables/b4d10b49c385aa405756fbbf572649d3/summary'
     )
     assert not validate_variable_url(var_catalog)
+
+
+def test_validate_uuid_ok():
+    assert validate_uuid('b2c4c6b7d3a94e58937b23c1fed1b65e') is True
+
+
+def test_validate_uuid_nok():
+    assert validate_uuid('12345') is False
 
 
 def _by_side_effect(shoji, entity_mock):
@@ -119,7 +128,7 @@ class TestUtilities(object):
         shoji_entity = {
             'element': 'shoji:entity',
             'body': {
-                'id': '123456',
+                'id': 'b2c4c6b7d3a94e58937b23c1fed1b65e',
                 'name': 'dataset_name',
                 'streaming': 'no'
             }
@@ -138,12 +147,12 @@ class TestUtilities(object):
         session.session.get.side_effect = _get
         session.catalogs.datasets = 'https://test.crunch.io/api/'
 
-        ds = get_mutable_dataset('123456')
-        session.session.get.assert_called_with('https://test.crunch.io/api/123456/')
+        ds = get_mutable_dataset('b2c4c6b7d3a94e58937b23c1fed1b65e')
+        session.session.get.assert_called_with('https://test.crunch.io/api/b2c4c6b7d3a94e58937b23c1fed1b65e/')
 
         assert isinstance(ds, MutableDataset)
         assert ds.name == 'dataset_name'
-        assert ds.id == '123456'
+        assert ds.id == 'b2c4c6b7d3a94e58937b23c1fed1b65e'
 
     @mock.patch('pycrunch.session')
     def test_get_project(self, session):


### PR DESCRIPTION
Improve `_get_dataset(…)` function so it makes less requests to crunch. If `dataset` parameter is a uuid, try loading it directly first.

When doing a `get_dataset(dsid)` it was first loading the `/datasets/` catalog, then `/datasets/{dsid}/`. It makes no sense to load the datasets catalog, specially when the user performing that task has many datasets as it makes the request really slow.

With this PR it validates if the given dataset reference is a valid uuid, and if so, it loads the dataset directly from dataset endpoint, without loading the catalog.