### PR TITLE
WIP: first thing for making a lazy mode of a dataset

### DIFF
--- a/scrunch/datasets.py
+++ b/scrunch/datasets.py
@@ -856,11 +856,13 @@ class DatasetVariablesMixin(collections.Mapping):
         """
         self._set_catalog()
         self._vars = self._catalog.index.items()
-        order = self._catalog.hier
 
-        # The `order` property, which provides a high-level API for
-        # manipulating the "Hierarchical Order" structure of a Dataset.
-        self.order = DatasetVariablesOrder(self._catalog, order)
+        if self.lazy is False:
+            order = self._catalog.hier
+
+            # The `order` property, which provides a high-level API for
+            # manipulating the "Hierarchical Order" structure of a Dataset.
+            self.order = DatasetVariablesOrder(self._catalog, order)
 
     def __iter__(self):
         for var in self._vars:
@@ -914,16 +916,18 @@ class BaseDataset(ReadOnly, DatasetVariablesMixin):
                           'viewers_can_share', 'dashboard_deck',
                           'variable_folders'}
 
-    def __init__(self, resource):
+    def __init__(self, resource, lazy=False):
         """
         :param resource: Points to a pycrunch Shoji Entity for a dataset.
         """
         super(BaseDataset, self).__init__(resource)
+        self.lazy = lazy
         self._settings = None
         # since we no longer have an __init__ on DatasetVariablesMixin because
         # of the multiple inheritance, we just initiate self._vars here
         self._reload_variables()
-        self.folders = DatasetFolders(self)
+        if self.lazy is False:
+            self.folders = DatasetFolders(self)
 
     def __getattr__(self, item):
         if item in self._ENTITY_ATTRIBUTES:

--- a/scrunch/mutable_dataset.py
+++ b/scrunch/mutable_dataset.py
@@ -8,7 +8,7 @@ from scrunch.expressions import parse_expr, process_expr
 from scrunch.helpers import shoji_entity_wrapper
 
 
-def get_mutable_dataset(dataset, connection=None, editor=False, project=None):
+def get_mutable_dataset(dataset, connection=None, editor=False, project=None, lazy=False):
     """
     A simple wrapper of _get_dataset with streaming=False
     """
@@ -17,7 +17,7 @@ def get_mutable_dataset(dataset, connection=None, editor=False, project=None):
     if shoji_ds['body'].get('streaming') == 'streaming':
         raise InvalidDatasetTypeError("Dataset %s is of type 'streaming',\
             use get_streaming_dataset method instead" % dataset)
-    ds = MutableDataset(shoji_ds)
+    ds = MutableDataset(shoji_ds, lazy=lazy)
     if editor is True:
         ds.change_editor(root.session.email)
     return ds

--- a/scrunch/streaming_dataset.py
+++ b/scrunch/streaming_dataset.py
@@ -4,7 +4,7 @@ from scrunch.exceptions import InvalidDatasetTypeError
 from scrunch.helpers import shoji_entity_wrapper
 
 
-def get_streaming_dataset(dataset, connection=None, editor=False, project=None):
+def get_streaming_dataset(dataset, connection=None, editor=False, project=None, lazy=False):
     """
     A simple wrapper of _get_dataset with streaming=True
     """
@@ -13,7 +13,7 @@ def get_streaming_dataset(dataset, connection=None, editor=False, project=None):
     if shoji_ds['body'].get('streaming') != 'streaming':
         raise InvalidDatasetTypeError("Dataset %s is of type 'mutable',\
             use get_mutable_dataset method instead" % dataset)
-    ds = StreamingDataset(shoji_ds)
+    ds = StreamingDataset(shoji_ds, lazy=lazy)
     if editor is True:
         ds.change_editor(root.session.email)
     return ds

--- a/scrunch/tests/test_datasets.py
+++ b/scrunch/tests/test_datasets.py
@@ -201,6 +201,32 @@ class TestDatasetBase(object):
 
 class TestDatasets(TestDatasetBase, TestCase):
 
+    def test_get_streaming_dataset(self):
+        ds_mock = self._dataset_mock()
+        ds = StreamingDataset(ds_mock)
+
+        assert ds.name == 'test_dataset_name'
+
+    def test_get_mutable_dataset(self):
+        ds_mock = self._dataset_mock()
+        ds = MutableDataset(ds_mock)
+
+        assert ds.name == 'test_dataset_name'
+
+    def test_get_streaming_lazy_dataset(self):
+        ds_mock = self._dataset_mock()
+        ds = StreamingDataset(ds_mock, lazy=True)
+
+        assert ds.name == 'test_dataset_name'
+        assert str(type(ds['var1_alias'])) == "<class 'scrunch.datasets.Variable'>"
+
+    def test_get_mutable_lazy_dataset(self):
+        ds_mock = self._dataset_mock()
+        ds = MutableDataset(ds_mock, lazy=True)
+
+        assert ds.name == 'test_dataset_name'
+        assert str(type(ds['var1_alias'])) == "<class 'scrunch.datasets.Variable'>"
+
     def test_edit_dataset(self):
         ds_mock = self._dataset_mock()
         ds = StreamingDataset(ds_mock)
@@ -2044,7 +2070,7 @@ class TestRecode(TestDatasetBase):
         }
         with pytest.raises(ValueError) as err:
             ds.create_categorical(**kwargs)
-        assert 'missing_case as an argument and as element of "categories" is not allowed' in str(err.value)        
+        assert 'missing_case as an argument and as element of "categories" is not allowed' in str(err.value)
 
     def test_create_categorical_missing_case(self):
         variables = {
@@ -2085,20 +2111,20 @@ class TestRecode(TestDatasetBase):
         }
         with pytest.raises(ValueError) as err:
             ds.create_categorical(**kwargs)
-        assert 'Entity test_dataset_name has no (sub)variable' in str(err.value) 
-        ds.resource.variables.create.assert_called_with({  
+        assert 'Entity test_dataset_name has no (sub)variable' in str(err.value)
+        ds.resource.variables.create.assert_called_with({
             'element':'shoji:entity',
-            'body':{  
+            'body':{
                 'name':'my mr',
                 'alias':'mr',
                 'description':'',
                 'notes':'',
                 'uniform_basis': False,
-                'derivation': {  
+                'derivation': {
                     'function':'array',
-                    'args': [{  
+                    'args': [{
                         'function':'select',
-                        'args': [{  
+                        'args': [{
                             'map': {
                                 '0001': {
                                     'references':{
@@ -2119,7 +2145,7 @@ class TestRecode(TestDatasetBase):
                                             }
                                         }
                                     },
-                                    {  
+                                    {
                                         'function':'==',
                                         'args':[
                                             {'variable':'https://test.crunch.io/api/datasets/123456/variables/var_a/'},
@@ -2139,7 +2165,7 @@ class TestRecode(TestDatasetBase):
                                             }]},
                                         {
                                             'function':'not',
-                                            'args':[{  
+                                            'args':[{
                                             'function':'==',
                                             'args':[
                                                 {'variable':'https://test.crunch.io/api/datasets/123456/variables/var_b/'},
@@ -2147,9 +2173,9 @@ class TestRecode(TestDatasetBase):
                                             ]}]
                                         }]
                                         },
-                                        {  
+                                        {
                                             'function':'==',
-                                            'args':[  
+                                            'args':[
                                                 {'variable':'https://test.crunch.io/api/datasets/123456/variables/var_b/'},
                                                 {'value':0}
                                             ]
@@ -2161,7 +2187,7 @@ class TestRecode(TestDatasetBase):
                                         'alias':'mr_2'
                                     },
                                     'function':'case',
-                                    'args':[{ 
+                                    'args':[{
                                         'column':[1, 2, -1],
                                         'type':{
                                             'value':{
@@ -2194,7 +2220,7 @@ class TestRecode(TestDatasetBase):
                                             }]},
                                         {
                                             'function':'not',
-                                            'args':[{  
+                                            'args':[{
                                             'function':'==',
                                             'args':[
                                                 {'variable':'https://test.crunch.io/api/datasets/123456/variables/var_b/'},
@@ -2204,7 +2230,7 @@ class TestRecode(TestDatasetBase):
                                     },
                                     {
                                         'function':'==',
-                                        'args':[  
+                                        'args':[
                                             {'variable':'https://test.crunch.io/api/datasets/123456/variables/var_b/'},
                                             {'value':0}
                                         ]


### PR DESCRIPTION
Introducing a lazy mode to datasets.

I have tested it out if we just want to get a variable.

With lazy=False:
`INFO:__main__:Running: ds = get_mutable_dataset('185264f6f5924235afbcfba1d717f0f7', lazy=False)
DEBUG:urllib3.connectionpool:Starting new HTTPS connection (1): app.crunch.io:443
DEBUG:urllib3.connectionpool:https://app.crunch.io:443 "GET /api/ HTTP/1.1" 401 168
DEBUG:urllib3.connectionpool:https://app.crunch.io:443 "POST /api/public/login/ HTTP/1.1" 204 0
DEBUG:urllib3.connectionpool:https://app.crunch.io:443 "GET /api/ HTTP/1.1" 200 401
DEBUG:urllib3.connectionpool:https://app.crunch.io:443 "GET /api/feature_flag/?feature_name=old_projects_order HTTP/1.1" 200 160
DEBUG:urllib3.connectionpool:https://app.crunch.io:443 "GET /api/datasets/185264f6f5924235afbcfba1d717f0f7/ HTTP/1.1" 200 921
DEBUG:urllib3.connectionpool:https://app.crunch.io:443 "GET /api/datasets/185264f6f5924235afbcfba1d717f0f7/variables/ HTTP/1.1" 200 588962
DEBUG:urllib3.connectionpool:https://app.crunch.io:443 "GET /api/datasets/185264f6f5924235afbcfba1d717f0f7/variables/hier/ HTTP/1.1" 200 24574
DEBUG:urllib3.connectionpool:https://app.crunch.io:443 "GET /api/datasets/185264f6f5924235afbcfba1d717f0f7/settings/ HTTP/1.1" 200 222
DEBUG:urllib3.connectionpool:https://app.crunch.io:443 "GET /api/datasets/185264f6f5924235afbcfba1d717f0f7/folders/ HTTP/1.1" 200 617
DEBUG:urllib3.connectionpool:https://app.crunch.io:443 "GET /api/datasets/185264f6f5924235afbcfba1d717f0f7/folders/ HTTP/1.1" 200 617
DEBUG:urllib3.connectionpool:https://app.crunch.io:443 "GET /api/datasets/185264f6f5924235afbcfba1d717f0f7/folders/hidden/ HTTP/1.1" 200 168
DEBUG:urllib3.connectionpool:https://app.crunch.io:443 "GET /api/datasets/185264f6f5924235afbcfba1d717f0f7/folders/ HTTP/1.1" 200 617
DEBUG:urllib3.connectionpool:https://app.crunch.io:443 "GET /api/datasets/185264f6f5924235afbcfba1d717f0f7/folders/trash/ HTTP/1.1" 200 166
INFO:__main__:Running: var = ds['abortion']
DEBUG:urllib3.connectionpool:https://app.crunch.io:443 "GET /api/datasets/185264f6f5924235afbcfba1d717f0f7/variables/000581/ HTTP/1.1" 200 628
INFO:__main__:Run time: 6.98 sec`

And with lazy=True:
INFO:__main__:Running: ds = get_mutable_dataset('185264f6f5924235afbcfba1d717f0f7', lazy=True)
DEBUG:urllib3.connectionpool:Starting new HTTPS connection (1): app.crunch.io:443
DEBUG:urllib3.connectionpool:https://app.crunch.io:443 "GET /api/ HTTP/1.1" 401 168
DEBUG:urllib3.connectionpool:https://app.crunch.io:443 "POST /api/public/login/ HTTP/1.1" 204 0
DEBUG:urllib3.connectionpool:https://app.crunch.io:443 "GET /api/ HTTP/1.1" 200 401
DEBUG:urllib3.connectionpool:https://app.crunch.io:443 "GET /api/feature_flag/?feature_name=old_projects_order HTTP/1.1" 200 160
DEBUG:urllib3.connectionpool:https://app.crunch.io:443 "GET /api/datasets/185264f6f5924235afbcfba1d717f0f7/ HTTP/1.1" 200 921
DEBUG:urllib3.connectionpool:https://app.crunch.io:443 "GET /api/datasets/185264f6f5924235afbcfba1d717f0f7/variables/ HTTP/1.1" 200 588962
INFO:__main__:Running: var = ds['abortion']
DEBUG:urllib3.connectionpool:https://app.crunch.io:443 "GET /api/datasets/185264f6f5924235afbcfba1d717f0f7/variables/000581/ HTTP/1.1" 200 628
INFO:__main__:Run time: 2.75 sec