### PR TITLE
Fix `Variable.move_to_folder`

### DIFF
--- a/integration/test_folders.py
+++ b/integration/test_folders.py
@@ -155,7 +155,7 @@ class TestFolders(TestCase):
         children = folder.children
         self.assertEqual([c.url for c in children],
             [c.url for c in [sf1, sf2, sf3, var]])
-        self.assertEqual(map(type, children),
+        self.assertEqual(list(map(type, children)),
                          [Folder, Folder, Folder, Variable])
 
         # Reorder placing sf1 at the end
@@ -169,7 +169,7 @@ class TestFolders(TestCase):
         self.assertEqual([c.url for c in folder.children],
             [c.url for c in [var, sf1, sf2, sf3]])
 
-    def move_to_folder(self):
+    def test_move_to_folder(self):
         ds = self.ds
         sf = ds.folders.root.create_folder("target")
         ds['testvar1'].move_to_folder(sf.path)

--- a/scrunch/datasets.py
+++ b/scrunch/datasets.py
@@ -2881,7 +2881,7 @@ class Variable(ReadOnly, DatasetSubvariablesMixin):
                                  before=before, after=after)
 
     def move_to_folder(self, path, position=None, after=None, before=None):
-        target = self.folders.get(path)
+        target = self.dataset.folders.get(path)
         target.move_here(self, position=position, after=after, before=before)
 
     def unbind(self):


### PR DESCRIPTION
closes #339 

Additionally I enabled the corresponding test function in the integration test file which revealed the same bug without this change. And there was another test function failing on py3 due to the different behavior of `map`.