### PR TITLE
Warn on usage of Dataset.change_owner, favor `Dataset.project` and `D…

### DIFF
--- a/scrunch/datasets.py
+++ b/scrunch/datasets.py
@@ -1046,8 +1046,7 @@ class BaseDataset(ReadOnly, DatasetVariablesMixin):
             if not isinstance(project, Project):
                 project = get_project(project)
 
-        project.move_here([self])
-        self.resource.refresh()
+        project.move_here([self])  # This performs .resource.refresh()
 
     @property
     def settings(self):

--- a/scrunch/datasets.py
+++ b/scrunch/datasets.py
@@ -6,7 +6,7 @@ import logging
 import os
 import re
 import sys
-
+from warnings import warn
 from math import fsum
 
 try:
@@ -19,7 +19,6 @@ except ImportError:
 import six
 
 import pycrunch
-from pycrunch.elements import JSONObject
 from pycrunch.exporting import export_dataset
 from pycrunch.shoji import Entity
 from scrunch.session import connect
@@ -994,7 +993,12 @@ class BaseDataset(ReadOnly, DatasetVariablesMixin):
         return MutableDataset(self.resource)
 
     @property
+    def project(self):
+        return Project(self.resource.project)
+
+    @property
     def owner(self):
+        warn("Access Dataset.project instead", DeprecationWarning)
         owner_url = self.resource.body.owner
         try:
             if '/users/' in owner_url:
@@ -1017,24 +1021,32 @@ class BaseDataset(ReadOnly, DatasetVariablesMixin):
         :param project: id, name or Project object
         :return:
         """
+        warn("Use Dataset.move() to move datasets between projects", DeprecationWarning)
         if user and project:
             raise AttributeError(
                 "Must provide user or project. Not both"
             )
-        owner_url = None
+
         if user:
+            warn("Changing owner to users is deprecated. Move to projects", DeprecationWarning)
             if not isinstance(user, User):
                 user = get_user(user)
             owner_url = user.url
+            self.resource.patch({'owner': owner_url})
+            self.resource.refresh()
+        elif project:
+            if not isinstance(project, Project):
+                project = get_project(project)
+            self.move(project)
+        else:
+            raise AttributeError("Can't set owner")
+
+    def move(self, project):
         if project:
             if not isinstance(project, Project):
                 project = get_project(project)
-            owner_url = project.url
 
-        if not owner_url:
-            raise AttributeError("Can't set owner")
-
-        self.resource.patch({'owner': owner_url})
+        project.move_here([self])
         self.resource.refresh()
 
     @property

--- a/scrunch/datasets.py
+++ b/scrunch/datasets.py
@@ -1042,9 +1042,8 @@ class BaseDataset(ReadOnly, DatasetVariablesMixin):
             raise AttributeError("Can't set owner")
 
     def move(self, project):
-        if project:
-            if not isinstance(project, Project):
-                project = get_project(project)
+        if not isinstance(project, Project):
+            project = get_project(project)
 
         project.move_here([self])  # This performs .resource.refresh()
 

--- a/scrunch/tests/test_datasets.py
+++ b/scrunch/tests/test_datasets.py
@@ -36,6 +36,7 @@ class AttributeDict(dict):
         super(AttributeDict, self).__init__(*args, **kwargs)
         self.__dict__ = self
 
+
 class dict_to_obj(object):
     def __init__(self, d):
         for a, b in d.items():
@@ -43,6 +44,7 @@ class dict_to_obj(object):
                setattr(self, a, [dict_to_obj(x) if isinstance(x, dict) else x for x in b])
             else:
                setattr(self, a, dict_to_obj(b) if isinstance(b, dict) else b)
+
 
 class _CrunchPayload(dict):
     def __init__(self, *args, **kwargs):
@@ -1524,7 +1526,6 @@ class TestCurrentOwner(TestDatasetBase, TestCase):
         dataset = StreamingDataset(dataset_resource)
         dataset.move(project)
         project.move_here.assert_called_once_with([dataset])
-        dataset_resource.refresh.assert_called_once()
 
     def test_owner_to_project(self):
         session = MockSession()
@@ -1552,7 +1553,6 @@ class TestCurrentOwner(TestDatasetBase, TestCase):
         ])
 
         project.move_here.assert_called_once_with([dataset])
-        dataset_resource.refresh.assert_called_once()
 
     def test_dataset_project(self):
         session = MockSession()
@@ -2910,7 +2910,7 @@ class TestRecode(TestDatasetBase):
                         }
                     ]
                 }
-            }            
+            }
         })
 
     def test_create_categorical_missing_case(self):

--- a/scrunch/tests/test_datasets.py
+++ b/scrunch/tests/test_datasets.py
@@ -17,6 +17,7 @@ except:
 from unittest import TestCase
 
 import pytest
+from pycrunch.shoji import Entity, Catalog, Order
 from pycrunch.elements import JSONObject, ElementSession
 from pycrunch.variables import cast
 
@@ -26,6 +27,8 @@ from scrunch.subentity import Filter, Multitable, Deck
 from scrunch.mutable_dataset import MutableDataset
 from scrunch.streaming_dataset import StreamingDataset
 from scrunch.tests.test_categories import EditableMock, TEST_CATEGORIES
+
+from .mock_session import MockSession
 
 
 class AttributeDict(dict):
@@ -1483,6 +1486,102 @@ class TestCurrentOwner(TestDatasetBase, TestCase):
         ds_mock.patch.assert_called_with({
             'owner': self.user_url
         })
+
+    def _load_dataset(self, dataset_resource):
+        dataset_resource.variables = MagicMock()
+        dataset_resource.settings = MagicMock()
+        dataset_resource.folders = MagicMock()
+        dataset_resource.refresh = MagicMock()
+
+    def _project(self, session, project_url):
+        project = Project(Entity(session, **{
+            "self": project_url,
+            "element": "shoji:entity",
+            "body": {
+                "name": "Targer project"
+            }
+        }))
+        project.move_here = MagicMock()
+        return project
+
+    def test_move_to_project(self):
+        session = MockSession()
+        project_url = 'http://host/api/projects/abc/'
+        dataset_url = 'http://host/api/projects/abc/'
+        dataset_resource = Entity(session, **{
+            "element": "shoji:entity",
+            "self": dataset_url,
+            "body": {
+                "name": "test_dataset_project"
+            },
+            "catalogs": {
+                "project": project_url,
+            }
+        })
+        self._load_dataset(dataset_resource)
+        project = self._project(session, project_url)
+
+        dataset = StreamingDataset(dataset_resource)
+        dataset.move(project)
+        project.move_here.assert_called_once_with([dataset])
+        dataset_resource.refresh.assert_called_once()
+
+    def test_owner_to_project(self):
+        session = MockSession()
+        project_url = 'http://host/api/projects/abc/'
+        dataset_url = 'http://host/api/projects/abc/'
+        dataset_resource = Entity(session, **{
+            "element": "shoji:entity",
+            "self": dataset_url,
+            "body": {
+                "name": "test_dataset_project"
+            },
+            "catalogs": {
+                "project": project_url,
+            }
+        })
+        self._load_dataset(dataset_resource)
+        project = self._project(session, project_url)
+
+        dataset = StreamingDataset(dataset_resource)
+        with mock.patch("scrunch.datasets.warn") as mock_warn:
+            dataset.change_owner(project=project)
+
+        mock_warn.assert_has_calls([
+            mock.call("Use Dataset.move() to move datasets between projects", DeprecationWarning)
+        ])
+
+        project.move_here.assert_called_once_with([dataset])
+        dataset_resource.refresh.assert_called_once()
+
+    def test_dataset_project(self):
+        session = MockSession()
+        project_url = 'http://host/api/projects/abc/'
+        dataset_url = 'http://host/api/projects/abc/'
+        dataset_resource = Entity(session, **{
+            "element": "shoji:entity",
+            "self": dataset_url,
+            "body": {
+                "name": "test_dataset_project"
+            },
+            "catalogs": {
+                "project": project_url,
+            }
+        })
+        self._load_dataset(dataset_resource)
+
+        project_payload = {
+            "element": "shoji:entity",
+            "self": project_url,
+            "body": {
+                "name": "My Project"
+            }
+        }
+        session.add_fixture(project_url, project_payload)
+        dataset = StreamingDataset(dataset_resource)
+        project = dataset.project
+        assert project.name == "My Project"
+        assert project.url == project_url
 
 
 class TestCast(TestCase):


### PR DESCRIPTION
We are going to move away from using the `Dataset.owner` as the way to detect and change the project where the dataset is stored.

The API should favor the usage of `Dataset.project` to get the containing project and `Dataset.move(project)` to change it. Deprecating `Dataset.owner` and `Dataset.change_owner`.