### PR TITLE
Fix cube usage

### DIFF
--- a/scrunch/cubes.py
+++ b/scrunch/cubes.py
@@ -3,7 +3,7 @@ import six
 from pycrunch.cubes import fetch_cube, count
 from scrunch.datasets import Variable
 from scrunch.expressions import parse_expr, process_expr
-from cr.cube.crunch_cube import CrunchCube
+from cr.cube.cube import Cube
 
 
 def variable_to_url(variable, dataset):
@@ -19,8 +19,8 @@ def variable_to_url(variable, dataset):
     return variable
 
 
-def crtabs(dataset, variables, weight=None, filter=None, **measures):
-    """Return CrunchCube representation of crosstab.
+def crtabs(dataset, variables, weight=None, filter=None, transforms=None, **measures):
+    """Return Cube representation of crosstab.
 
     :param dataset: Dataset instance
     :param variables: List of variable urls, aliases or Variable instances
@@ -33,5 +33,14 @@ def crtabs(dataset, variables, weight=None, filter=None, **measures):
     if filter is not None:
         filter = process_expr(parse_expr(filter), dataset.resource)
 
-    return CrunchCube(fetch_cube(
-        dataset.resource, variables, count=count(), weight=weight, filter=filter, **measures))
+    return Cube(
+        fetch_cube(
+            dataset.resource,
+            variables,
+            count=count(),
+            weight=weight,
+            filter=filter,
+            **measures
+        ),
+        transforms=transforms,
+    )

--- a/scrunch/cubes.py
+++ b/scrunch/cubes.py
@@ -19,19 +19,20 @@ def variable_to_url(variable, dataset):
     return variable
 
 
-def crtabs(dataset, variables, weight=None, filter=None, transforms=None, **measures):
+def crtabs(dataset, variables, weight=None, filter_=None, transforms=None, **measures):
     """Return Cube representation of crosstab.
 
     :param dataset: Dataset instance
     :param variables: List of variable urls, aliases or Variable instances
     :param weight: Scrunch variable instance, alias or url
-    :param filter: Scrunch filter expression
+    :param filter_: Scrunch filter expression
+    :param transforms: cr.cube transforms dictionary
     """
     variables = [variable_to_url(var, dataset) for var in variables]
     if weight is not None:
         weight = variable_to_url(weight, dataset)
-    if filter is not None:
-        filter = process_expr(parse_expr(filter), dataset.resource)
+    if filter_ is not None:
+        filter_ = process_expr(parse_expr(filter_), dataset.resource)
 
     return Cube(
         fetch_cube(
@@ -39,7 +40,7 @@ def crtabs(dataset, variables, weight=None, filter=None, transforms=None, **meas
             variables,
             count=count(),
             weight=weight,
-            filter=filter,
+            filter=filter_,
             **measures
         ),
         transforms=transforms,

--- a/scrunch/tests/test_cubes.py
+++ b/scrunch/tests/test_cubes.py
@@ -1,56 +1,58 @@
-import pytest
-from mock import patch, MagicMock
+from mock import patch
 from unittest import TestCase
 
-from pycrunch.cubes import fetch_cube, count
+from pycrunch.cubes import count
 from scrunch.streaming_dataset import StreamingDataset
 from scrunch.tests.test_datasets import TestDatasetBase
 from scrunch.cubes import crtabs, variable_to_url
-from scrunch.datasets import Variable
 
 
 class TestCubes(TestDatasetBase, TestCase):
-
-    @patch('scrunch.cubes.fetch_cube')
+    @patch("scrunch.cubes.fetch_cube")
     def test_crtabs_passes_string_arguments(self, mock_fetch_cube):
         """
         Test url aliases are converted to urls
         """
         ds_mock = self._dataset_mock()
         ds = StreamingDataset(ds_mock)
-        variables = ['var1_alias', 'var2_alias']
+        variables = ["var1_alias", "var2_alias"]
         urls = [variable_to_url(var, ds) for var in variables]
         crtabs(dataset=ds, variables=variables)
         mock_fetch_cube.assert_called_once_with(
-            ds.resource, urls, count=count(), weight=None, filter=None)
+            ds.resource, urls, count=count(), weight=None, filter=None
+        )
 
-    @patch('scrunch.cubes.fetch_cube')
+    @patch("scrunch.cubes.fetch_cube")
     def test_weight_to_url(self, mock_fetch_cube):
         """
         Test weight alias is converted to url
         """
         ds_mock = self._dataset_mock()
         ds = StreamingDataset(ds_mock)
-        variables = ['var1_alias', 'var2_alias']
-        weight_url = variable_to_url('var3_alias', ds)
+        variables = ["var1_alias", "var2_alias"]
+        weight_url = variable_to_url("var3_alias", ds)
         urls = [variable_to_url(var, ds) for var in variables]
-        crtabs(dataset=ds, variables=variables, weight='var3_alias')
+        crtabs(dataset=ds, variables=variables, weight="var3_alias")
         mock_fetch_cube.assert_called_once_with(
-            ds.resource, urls, count=count(), weight=weight_url, filter=None)
+            ds.resource, urls, count=count(), weight=weight_url, filter=None
+        )
 
-    @patch('scrunch.cubes.fetch_cube')
+    @patch("scrunch.cubes.fetch_cube")
     def test_pass_filter_expression(self, mock_fetch_cube):
         ds_mock = self._dataset_mock()
         ds = StreamingDataset(ds_mock)
-        variables = ['var1_alias', 'var2_alias']
+        variables = ["var1_alias", "var2_alias"]
         urls = [variable_to_url(var, ds) for var in variables]
-        crtabs(dataset=ds, variables=variables, filter='var1_alias > 1')
+        crtabs(dataset=ds, variables=variables, filter_="var1_alias > 1")
         processed_filter = {
-            'function': '>',
-            'args': [
-                {'variable': 'https://test.crunch.io/api/datasets/123456/variables/0001/'},
-                {'value': 1}
-            ]
+            "function": ">",
+            "args": [
+                {
+                    "variable": "https://test.crunch.io/api/datasets/123456/variables/0001/"
+                },
+                {"value": 1},
+            ],
         }
         mock_fetch_cube.assert_called_once_with(
-            ds.resource, urls, count=count(), filter=processed_filter, weight=None)
+            ds.resource, urls, count=count(), filter=processed_filter, weight=None
+        )


### PR DESCRIPTION
Replace the deprecated `CrunchCube` object with the `Cube` one. All the methods should now be properties, which should be much easier to use.