### PR TITLE
BaseDataset.replace_values should not include parameters when executing a POST 

### DIFF
--- a/scrunch/datasets.py
+++ b/scrunch/datasets.py
@@ -2386,9 +2386,10 @@ class BaseDataset(ReadOnly, DatasetVariablesMixin):
                     payload['variables'][self[alias].id] = {'value': val}
         if filter:
             payload['filter'] = process_expr(parse_expr(filter), self.resource)
-            # Remove query parameters from table url
-            table = self.resource.table
-            table.self = table.self[:table.self.find('?')]
+
+        # Remove query parameters from table url
+        table = self.resource.table
+        table.self = table.self[:table.self.find('?')]
 
         resp = self.resource.table.post(json.dumps(payload))
         if resp.status_code == 204:

--- a/scrunch/datasets.py
+++ b/scrunch/datasets.py
@@ -2386,6 +2386,9 @@ class BaseDataset(ReadOnly, DatasetVariablesMixin):
                     payload['variables'][self[alias].id] = {'value': val}
         if filter:
             payload['filter'] = process_expr(parse_expr(filter), self.resource)
+            # Remove query parameters from table url
+            table = self.resource.table
+            table.self = table.self[:table.self.find('?')]
 
         resp = self.resource.table.post(json.dumps(payload))
         if resp.status_code == 204:


### PR DESCRIPTION
When a `filter` is passed in `BaseDataset.replace_values()` ...

- `process_expr` is called
- `process_expr` calls `get_dataset_variables`
- `get_dataset_variables` calls table endpoint, setting `limit=0` parameter on the table url
- back to `replace_values`, it then executes post on table resource, which now is set to have `?limit=0`

This pull request will clear the remove the parameters from the table resource url, if filter is passed, before executing a POST, thus avoiding the 404 errors 