### PR TITLE
Add `fill` support

### DIFF
--- a/integration/test_recodes.py
+++ b/integration/test_recodes.py
@@ -222,6 +222,6 @@ class TestFill(TestCase):
             cats["Weekly"],
             cats["Daily"],
         ])
-
+        ds.delete()
 
 

--- a/integration/test_recodes.py
+++ b/integration/test_recodes.py
@@ -14,6 +14,9 @@ from unittest import TestCase
 from fixtures import NEWS_DATASET, NEWS_DATASET_ROWS, mr_in, RECODES_CSV_OUTPUT
 from scrunch import connect
 from scrunch.streaming_dataset import get_streaming_dataset
+from scrunch.mutable_dataset import get_mutable_dataset
+from pycrunch.importing import Importer
+
 
 HOST = os.environ['SCRUNCH_HOST']
 username = os.environ['SCRUNCH_USER']
@@ -21,6 +24,7 @@ password = os.environ['SCRUNCH_PASS']
 
 
 site = connect(username, password, HOST)
+assert site is not None, "Unable to connect to %s" % HOST
 
 
 class TestRecodes(TestCase):
@@ -125,7 +129,6 @@ class TestRecodes(TestCase):
         reader = csv.reader(StringIO(RECODES_CSV_OUTPUT))
         headers = reader.next()
 
-
         # rewrite the actual csv in the same order as the expected csv
         actualf = StringIO()
         writer = csv.writer(actualf)
@@ -141,3 +144,84 @@ class TestRecodes(TestCase):
 
         output.close()
         ds.delete()
+
+
+class TestFill(TestCase):
+    def test_fill(self):
+        cats = [
+            {"id": 1, "name": "Daily", "missing": False, "numeric_value": None},
+            {"id": 2, "name": "Weekly", "missing": False, "numeric_value": None},
+            {"id": 3, "name": "Monthly", "missing": False, "numeric_value": None},
+            {"id": -1, "name": "No Data", "missing": True, "numeric_value": None},
+        ]
+        metadata = {
+            "coke_freq": {
+                "name": "frequency coke",
+                "type": "categorical",
+                "categories": cats
+            },
+            "pepsi_freq": {
+                "name": "frequency pepsi",
+                "type": "categorical",
+                "categories": cats
+            },
+            "pop_pref": {
+                "name": "Soda preference",
+                "type": "categorical",
+                "categories": [
+                    {"id": 1, "name": "Coke", "missing": False, "numeric_value": None},
+                    {"id": 2, "name": "Pepsi", "missing": False, "numeric_value": None},
+                    {"id": -1, "name": "No Data", "missing": True, "numeric_value": None},
+                ]
+            }
+        }
+        ds_payload = {
+            'element': 'shoji:entity',
+            'body': {
+                'name': 'test_fill',
+                'table': {
+                    'element': 'crunch:table',
+                    'metadata': metadata
+                },
+            }
+        }
+
+        rows = [
+            ["coke_freq", "pepsi_freq", "pop_pref"],
+            [1,            3,            1],
+            [2,            2,            1],
+            [3,            1,            1],
+            [1,            3,            2],
+            [2,            2,            2],
+            [3,            1,            2],
+        ]
+        ds = site.datasets.create(ds_payload).refresh()
+        dataset = get_mutable_dataset(ds.body.id, site)
+        Importer().append_rows(ds, rows)
+
+        dataset.create_fill_values([
+            {"case": "pop_pref == 1", "variable": "coke_freq"},
+            {"case": "pop_pref == 2", "variable": "pepsi_freq"},
+        ], alias="pop_freq", name="Pop frequency")
+
+        variables = ds.variables.by("alias")
+        new_id = variables["pop_freq"]["id"]
+        new_var = variables["pop_freq"].entity
+        self.assertTrue(new_var.body.derived)
+        self.assertEqual(new_var.body.name, "Pop frequency")
+
+        data = ds.follow("table", "limit=6")
+        cats = {c["name"]: c["id"] for c in data["metadata"][new_id]["categories"]}
+        self.assertEqual(data["data"][new_id], [
+            # Coke chunk
+            cats["Daily"],
+            cats["Weekly"],
+            cats["Monthly"],
+            # Pepsi chunk
+            cats["Monthly"],
+            cats["Weekly"],
+            cats["Daily"],
+        ])
+
+
+

--- a/scrunch/datasets.py
+++ b/scrunch/datasets.py
@@ -1205,6 +1205,68 @@ class BaseDataset(ReadOnly, DatasetVariablesMixin):
         }
         self.resource.permissions.patch(payload)
 
+    def create_fill_values(self, variables, name, alias, description=''):
+        """
+        This function is similar to create_single_categorical in the sense
+        that the output is a 1D variable.
+
+        Will create a derived variable using a combination of Crunch's `fill`
+        and `case` functions, to create a new variable using the values from
+        the specified variables according to each expression.
+
+            dataset.create_fill_values([
+                {"case": "pop_pref == 1", "variable": "coke_freq"},
+                {"case": "pop_pref == 2", "variable": "pepsi_freq"},
+            ], alias="pop_freq", name="Pop frequency")
+
+        :param variables: list of dictionaries with an `variable` and `case`
+        :param name: Name of the new variable
+        :param alias: Alias of the new variable
+        :param description: Description of the new variable
+        :return:
+        """
+        if not hasattr(self.resource, 'variables'):
+            self.resource.refresh()
+
+        aliases = {c["variable"] for c in variables}
+        vars_by_alias = self.resource.variables.by("alias")
+        types = {vars_by_alias[al]["type"] for al in aliases}
+        if types != {"categorical"}:
+            raise ValueError("All variables must be of type `categorical`")
+
+        cat_ids = list(range(1, len(variables) + 1))
+        args = [{
+            "column": cat_ids,
+            "type": {
+                "class": "categorical",
+                "ordinal": False,
+                "categories": [
+                    {"id": c, "name": str(c), "missing": False, "numeric_value": None}
+                    for c in cat_ids
+                ]
+            }
+        }]
+        exprs = [parse_expr(c["case"]) for c in variables]
+        exprs = process_expr(exprs, self.resource)
+        args.extend(exprs)
+        expr = {"function": "case", "args": args}
+        fill_map = {str(cid): {"variable": vars_by_alias[v["variable"]]["id"]}
+                    for cid, v in zip(cat_ids, variables)}
+        fill_expr = {
+            "function": "fill",
+            "args": [
+                expr,
+                {"map": fill_map}
+            ]
+        }
+        payload = shoji_entity_wrapper({
+            "alias": alias,
+            "name": name,
+            "description": description,
+            "derivation": fill_expr
+        })
+        return self._var_create_reload_return(payload)
+
     def create_single_response(self, categories, name, alias, description='',
         missing=True, notes=''):
         """

--- a/scrunch/tests/test_datasets.py
+++ b/scrunch/tests/test_datasets.py
@@ -1971,15 +1971,18 @@ class TestFillVariables(TestCase):
             "index": {
                 "001": {
                     "alias": "var_a",
-                    "type": "categorical"
+                    "type": "categorical",
+                    "id": "001",
                 },
                 "002": {
                     "alias": "var_b",
-                    "type": "categorical"
+                    "type": "categorical",
+                    "id": "002",
                 },
                 new_var_url: {
                     "alias": "filled",
-                    "type": "categorical"
+                    "type": "categorical",
+                    "id": "123"
                 }
             },
             "catalogs": {
@@ -2018,10 +2021,8 @@ class TestFillVariables(TestCase):
         }
         session.add_post_response(response)
 
-        # Mocks that aren't reelevant for the test
-        dataset_resource.settings = MagicMock()
+        # Mocks that aren't relevant for the test
         dataset_resource.folders = MagicMock()
-        dataset_resource.refresh = MagicMock()
 
         ds = StreamingDataset(dataset_resource)
         responses = [
@@ -2071,8 +2072,8 @@ class TestFillVariables(TestCase):
                 case_expr,
                 {
                     "map": {
-                        "1": {"variable": "var_a"},
-                        "2": {"variable": "var_b"}
+                        "1": {"variable": "001"},
+                        "2": {"variable": "002"}
                     }
                 }
             ],
@@ -2082,7 +2083,8 @@ class TestFillVariables(TestCase):
             "body": {
                 "alias": "filled",
                 "derivation": fill_expr,
-                "name": "Filled var"
+                "name": "Filled var",
+                "description": ""
             },
         })
 


### PR DESCRIPTION
Add support for categorical `fill` variables via the `create_fill_values` method 