### PR TITLE
Make `Dataset.replace_values()` wait for the progress to finish for A…

### DIFF
--- a/integration/test_dataset.py
+++ b/integration/test_dataset.py
@@ -1,0 +1,53 @@
+# coding: utf-8
+
+import os
+from unittest import TestCase
+
+from scrunch import connect
+from scrunch.mutable_dataset import get_mutable_dataset
+
+HOST = os.environ['SCRUNCH_HOST']
+username = os.environ['SCRUNCH_USER']
+password = os.environ['SCRUNCH_PASS']
+
+
+site = connect(username, password, HOST)
+assert site is not None, "Unable to connect to %s" % HOST
+
+as_entity = lambda b: {
+    "element": "shoji:entity",
+    "body": b
+}
+
+
+class TestDatasetMethods(TestCase):
+    def test_replace_values(self):
+        ds = site.datasets.create(as_entity({"name": "test_replace_values"})).refresh()
+        variable = ds.variables.create(
+            as_entity(
+                {
+                    "name": "my_var",
+                    "alias": "my_var",
+                    "type": "numeric",
+                    "values": [1, 2, 3, None, 5],
+                }
+            )
+        ).refresh()
+        scrunch_dataset = get_mutable_dataset(ds.body.id, site)
+        resp = scrunch_dataset.replace_values({
+            "my_var": 4
+        }, filter="missing(my_var)")
+        if resp is not None:
+            # We got a 202 response. Scrunch should have waited for the
+            # progress to finish
+            progress_url = resp.payload["value"]
+            progress = site.session.get(progress_url)
+            progress_status = progress.payload["value"]
+            assert progress_status == 100
+        else:
+            # This means the API handled this synchronously. 204 response
+            pass
+
+        r = ds.follow("table", "limit=10")["data"]
+        assert r[variable.body["id"]] == [1, 2, 3, 4, 5]
+        ds.delete()

--- a/scrunch/datasets.py
+++ b/scrunch/datasets.py
@@ -2537,6 +2537,7 @@ class BaseDataset(ReadOnly, DatasetVariablesMixin):
         if resp.status_code == 204:
             LOG.info('Dataset Updated')
             return
+        pycrunch.shoji.wait_progress(resp, self.resource.session)
         return resp
 
     def backfill_from_csv(self, aliases, pk_alias, csv_fh, rows_filter):

--- a/scrunch/tests/test_datasets.py
+++ b/scrunch/tests/test_datasets.py
@@ -322,6 +322,9 @@ class TestDatasets(TestDatasetBase, TestCase):
         ds = MutableDataset(ds_mock)
         ds.resource = MagicMock()
         ds.resource.table = self.Table(session=MagicMock(), self='http://a/?b=c')
+        post_mock = MagicMock()
+        post_mock.side_effect = [MagicMock(status_code=204)]
+        setattr(ds.resource.table, "post", post_mock)
         ds.replace_values({'var3_alias': 1}, filter='var4_alias == 2')
         assert ds.resource.table.self == 'http://a/'
 

--- a/scrunch/tests/test_datasets.py
+++ b/scrunch/tests/test_datasets.py
@@ -283,7 +283,7 @@ class TestDatasets(TestDatasetBase, TestCase):
         assert ds.resource.body.get('streaming') == 'negative'
 
     @mock.patch('scrunch.datasets.process_expr')
-    def test_replace_values(self, mocked_process):
+    def test_replace_values_sync(self, mocked_process):
         mocked_process.side_effect = self.process_expr_side_effect
         variables = {
             '001': {
@@ -302,6 +302,7 @@ class TestDatasets(TestDatasetBase, TestCase):
         ds_mock = self._dataset_mock(variables=variables)
         ds = MutableDataset(ds_mock)
         ds.resource = MagicMock()
+        ds.resource.table.post.side_effect = [MagicMock(status_code=204)]
         ds.replace_values({'birthyr': 9, 'level': 8})
         call = json.loads(ds.resource.table.post.call_args[0][0])
         assert 'command' in call


### PR DESCRIPTION
…synchronous responses