### PR TITLE
Fix table url that contains query string in BaseDataset.replace_values

### DIFF
--- a/scrunch/datasets.py
+++ b/scrunch/datasets.py
@@ -2535,10 +2535,6 @@ class BaseDataset(ReadOnly, DatasetVariablesMixin):
         if filter:
             payload['filter'] = process_expr(parse_expr(filter), self.resource)
 
-        # Remove query parameters from table url
-        table = self.resource.table
-        table.self = table.self[:table.self.find('?')]
-
         resp = self.resource.table.post(json.dumps(payload))
         if resp.status_code == 204:
             LOG.info('Dataset Updated')

--- a/scrunch/expressions.py
+++ b/scrunch/expressions.py
@@ -427,9 +427,7 @@ def parse_expr(expr):
 
 
 def get_dataset_variables(ds):
-    table = ds.follow("table", urlencode({
-        'limit': 0
-    }))
+    table = ds.follow("table")
 
     # Build the variables dict, using `alias` as the key.
     variables = dict()

--- a/scrunch/tests/test_datasets.py
+++ b/scrunch/tests/test_datasets.py
@@ -316,19 +316,6 @@ class TestDatasets(TestDatasetBase, TestCase):
         assert call['variables']['002']['value'] == 8
 
     @mock.patch('scrunch.datasets.process_expr')
-    def test_replace_values_filter(self, mocked_process):
-        mocked_process.side_effect = self.process_expr_side_effect
-        ds_mock = self._dataset_mock()
-        ds = MutableDataset(ds_mock)
-        ds.resource = MagicMock()
-        ds.resource.table = self.Table(session=MagicMock(), self='http://a/?b=c')
-        post_mock = MagicMock()
-        post_mock.side_effect = [MagicMock(status_code=204)]
-        setattr(ds.resource.table, "post", post_mock)
-        ds.replace_values({'var3_alias': 1}, filter='var4_alias == 2')
-        assert ds.resource.table.self == 'http://a/'
-
-    @mock.patch('scrunch.datasets.process_expr')
     def test_create_numeric(self, mocked_process):
         mocked_process.side_effect = self.process_expr_side_effect
         variables = {

--- a/scrunch/tests/test_expressions.py
+++ b/scrunch/tests/test_expressions.py
@@ -4,7 +4,7 @@ from unittest import TestCase, mock
 import scrunch
 from scrunch.datasets import parse_expr
 from scrunch.datasets import process_expr
-from scrunch.expressions import prettify
+from scrunch.expressions import prettify, get_dataset_variables
 
 
 class TestExpressionParsing(TestCase):
@@ -3444,3 +3444,18 @@ class TestDateTimeExpression(TestCase):
                 }
             ]
         }
+
+
+class TestGetDatasetVariables(TestCase):
+    """
+    Test for get_dataset_variables not adding param 'limit=0' in ds.follow
+    """
+
+    ds_url = 'http://test.crunch.io/api/datasets/12345/'
+
+    def test_follow(self):
+        ds = mock.MagicMock()
+        ds.self = self.ds_url
+        ds.follow.return_value = mock.MagicMock(metadata={})
+        _ = get_dataset_variables(ds)
+        ds.follow.assert_called_once_with("table")


### PR DESCRIPTION
This pull request https://github.com/Crunch-io/scrunch/pull/385 aimed to take care of the error

```
<Response [404]>, 'https://app.crunch.io/api/datasets/<dataset id>/table/?limit=0', {'status': '404 Not Found', 'message': 'Nothing matches the given URI'}
```

when using the `BaseDataset.replace_values` method. This seems not to work since the post is not done on the updated url.

Since the `limit=0` is the default for the table endpoint in crunch, we should remove it in `get_dataset_variables` and then we won't have a query string on the url in `BaseDataset.replace_values` when doing the post.