### PR TITLE
Use root's dataset catalog to create new views

### DIFF
--- a/integration/test_views.py
+++ b/integration/test_views.py
@@ -61,6 +61,7 @@ class TestViews(TestCase):
 
         # Assert it is a view
         assert new_view.resource.body["view_of"] == api_ds.self
+        assert new_view.resource.body["owner"] == project.self
 
         # Assert the variables are here
         for alias, v_type in self.FIXTURE_VARIABLES:

--- a/integration/test_views.py
+++ b/integration/test_views.py
@@ -49,6 +49,23 @@ class TestViews(TestCase):
         for alias, v_type in self.FIXTURE_VARIABLES:
             assert new_view[alias].type == v_type
 
+    def test_create_view_non_personal_ds(self):
+        api_ds = self._create_ds()
+
+        # Put the dataset in a public project
+        project = site.projects.create(as_entity({"name": "public project"}))
+        project.patch({"index": {api_ds.self: {}}})
+
+        scrunch_dataset = get_mutable_dataset(api_ds.body.id, site, editor=True)
+        new_view = scrunch_dataset.views.create("My view", None)
+
+        # Assert it is a view
+        assert new_view.resource.body["view_of"] == api_ds.self
+
+        # Assert the variables are here
+        for alias, v_type in self.FIXTURE_VARIABLES:
+            assert new_view[alias].type == v_type
+
     def test_create_var_subset(self):
         api_ds = self._create_ds()
         scrunch_dataset = get_mutable_dataset(api_ds.body.id, site, editor=True)

--- a/scrunch/views.py
+++ b/scrunch/views.py
@@ -17,7 +17,8 @@ class DatasetViews:
         """
         view_args = {
             "name": name,
-            "view_of": self.dataset_resource.self
+            "view_of": self.dataset_resource.self,
+            "owner": self.dataset_resource.body["owner"]
         }
         if columns is not None:
             # Columns is a list of aliases, convert to URLs
@@ -25,7 +26,7 @@ class DatasetViews:
             columns_url = [alias_2_url[a].entity_url for a in columns]
             view_args["view_cols"] = columns_url
 
-        project = self.dataset_resource.parent
+        project = self.dataset_resource.session.root.datasets
         view_res = project.create(shoji_entity_wrapper(view_args))
         view_res.refresh()
 


### PR DESCRIPTION
Use the root's datasets catalog to create new views instead of the `.parent` attribute from the dataset, since it doesn't always points to a catalog that allows dataset creation.