### PR TITLE
[184376107]: does this fix build?

### DIFF
--- a/integration/test_scripts.py
+++ b/integration/test_scripts.py
@@ -73,7 +73,7 @@ class TestScripts(TestCase):
         assert len(async_script) > 2 ** 20  # This is the threshold for async
         with pytest.raises(ScriptExecutionError) as err:
             scrunch_dataset.scripts.execute(async_script)
-        assert len(err.value.resolutions) == 50000  # All lines raised error
+        assert len(err.value.resolutions) == 10000  # All lines raised error
         resolutions = err.value.resolutions[0]
         assert resolutions["column"] == 1
         assert resolutions["line"] == 1

--- a/integration/test_scripts.py
+++ b/integration/test_scripts.py
@@ -65,7 +65,10 @@ class TestScripts(TestCase):
         assert resolutions["message"] == "Invalid command: BAD"
 
         # Script big enough to trigger async validation
-        async_script = ["""BAD-RENAME pk TO varA;"""] * 50000
+        async_script = [
+            """BAD-RENAME pk TO varA; # A comment to make each line longer... """
+            """And longer....................................................."""
+        ] * 10000
         async_script = "\n".join(async_script)
         assert len(async_script) > 2 ** 20  # This is the threshold for async
         with pytest.raises(ScriptExecutionError) as err:


### PR DESCRIPTION
@ernestoarbitrio - looks like there are a ton of problems in with the build system, but the scrunch failures seem centered around taking a long time to validate a failed script. I wondered if the problem was that the new error handling slowed down parsing thus leading to our current build failures. Adding a comment assuming that having less lines (but similar number of characters) would fix it, but maybe should have added them on a new line. Do you have a way to benchmark these scrunch changes and see if they're meaningfully faster?

Here's the error info:
```
self = <test_scripts.TestScripts testMethod=test_handle_error>

    def test_handle_error(self):
        ds, variable = self._create_ds()
        scrunch_dataset = get_mutable_dataset(ds.body.id, site)
        script = """BAD-RENAME pk TO varA;"""  # Bad syntax script
        with pytest.raises(ScriptExecutionError) as err:
            scrunch_dataset.scripts.execute(script)
    
        variable.refresh()
        assert variable.body["alias"] == "pk"  # Unchanged
        resolutions = err.value.resolutions[0]
        assert resolutions["column"] == 1
        assert resolutions["line"] == 1
        assert resolutions["command"] == 1
        assert resolutions["message"] == "Invalid command: BAD"
    
        # Script big enough to trigger async validation
        async_script = ["""BAD-RENAME pk TO varA;"""] * 50000
        async_script = "\n".join(async_script)
        assert len(async_script) > 2 ** 20  # This is the threshold for async
        with pytest.raises(ScriptExecutionError) as err:
>           scrunch_dataset.scripts.execute(async_script)

scrunch_functests/integration/test_scripts.py:72: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
scrunch_functests/scrunch/scripts.py:28: in execute
    'body': {"body": script_body},
venv/lib/python3.6/site-packages/pycrunch/shoji.py:182: in create
    return self._wait_for_progress(entity, response, progress_tracker)
venv/lib/python3.6/site-packages/pycrunch/shoji.py:195: in _wait_for_progress
    entity.wait_progress(r, progress_tracker)
venv/lib/python3.6/site-packages/pycrunch/shoji.py:282: in wait_progress
    wait_progress(r, self.session, progress_tracker, entity=self)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

r = <Response [202]>
session = <scrunch.session.ScrunchSession object at 0x7f6f2d14d5f8>
progress_tracker = <pycrunch.progress.DefaultProgressTracking object at 0x7f6f2d14db38>
entity = {'element': 'shoji:entity', 'body': {'body': 'BAD-RENAME pk TO varA;\nBAD-RENAME pk TO varA;\nBAD-RENAME pk TO varA;\n...: 'https://unstable.crunch.io/api/datasets/832487b056c84082a1d71821c7c8d429/scripts/262d9d5a715e4084ba8c8bce315f6cf2/'}

    def wait_progress(r, session, progress_tracker=None, entity=None):
        """Waits for completion of an Entity or View from API response
        that provides progress reporting.
    
        The entity will be updated with the location provided by the response
        and the method will wait until progress completed or progress tracker
        did timeout.
    
        User need to manually call ``.refresh()`` when the progress completed
        to fetch the updated entity.
    
        A custom ``progress_tracker`` can be passed to override the one
        provided by session. Progress trackers provide a way to configure
        timeout, polling interval and reporting callbacks.
    
        See `pycrunch.progress.DefaultProgressTracking` and
        `pycrunch.progress.SimpleTextBarProgressTracking` for documentation
        regarding progress trackers.
        """
        progress_url = r.payload["value"]
    
        if progress_tracker is None:
            progress_tracker = session.progress_tracking
    
        timeout = progress_tracker.timeout
        progress_state = progress_tracker.start_progress()
        begin = time.time()
        while timeout is None or time.time() - begin < timeout:
            prog_r = session.get(progress_url)
            progress = prog_r.payload["value"]
            progress_tracker.on_progress(progress_state, progress)
            if progress["progress"] == -1:
                # Completed due to error
                raise TaskError(progress["message"])
            elif progress["progress"] == 100:
                # Completed with success
                break
            time.sleep(progress_tracker.interval)
        else:
            # Loop completed due to timeout
>           raise TaskProgressTimeoutError(entity, r, timeout=timeout)
E           pycrunch.shoji.TaskProgressTimeoutError: Task Progress did not complete before 30 seconds timeout. Trap this exception and call exc.entity.wait_progress(exc.response) to wait for completion explicitly.
```