### PR TITLE
Making scrunch compatible with Python 3.11

### DIFF
--- a/scrunch/datasets.py
+++ b/scrunch/datasets.py
@@ -14,6 +14,12 @@ except ImportError:
     # ... unless you have to worry about pandas
     pd = None
 
+
+if sys.version_info.major == 3:
+    from collections.abc import Mapping
+else:
+    from collections import Mapping
+
 import six
 
 import pycrunch
@@ -702,7 +708,7 @@ class DatasetSettings(dict):
     del __readonly__
 
 
-class DatasetVariablesMixin(collections.Mapping):
+class DatasetVariablesMixin(Mapping):
     """
     Handles dataset variable iteration in a dict-like way
     """
@@ -3410,5 +3416,4 @@ class BackfillFromCSV:
                     folders_by_name[folder_name].entity.delete()
                 # Always delete the tmp dataset no matter what
                 tmp_ds.delete()
-
 

--- a/scrunch/expressions.py
+++ b/scrunch/expressions.py
@@ -48,6 +48,9 @@ import six
 import scrunch
 from scrunch.variables import validate_variable_url
 
+import sys
+
+PY311 = sys.version_info[:2] == (3, 11)
 
 if six.PY2:
     from urllib import urlencode
@@ -280,9 +283,13 @@ def parse_expr(expr):
                 # We will take the subvariable alias bit from the subscript
                 # and return an object with the array and subvariable alias
                 array_alias = dict(ast.iter_fields(fields[0][1]))["id"]
-                name_node = dict(ast.iter_fields(fields[1][1]))["value"]
-                subscript_fields = dict(ast.iter_fields(name_node))
-                subvariable_alias = subscript_fields["id"]
+                if PY311:                
+                    name_node = dict(ast.iter_fields(fields[1][1]))
+                    subvariable_alias = name_node["id"]
+                else:
+                    name_node = dict(ast.iter_fields(fields[1][1]))["value"]
+                    subscript_fields = dict(ast.iter_fields(name_node))
+                    subvariable_alias = subscript_fields["id"]
                 return {"variable": {"array": array_alias, "subvariable": subvariable_alias}}
             # "Non-terminal" nodes.
             else:

--- a/scrunch/order.py
+++ b/scrunch/order.py
@@ -3,6 +3,12 @@ import json
 import re
 
 import six
+import sys
+
+if sys.version_info.major == 3:
+    from collections.abc import Iterable
+else:
+    from collections import Iterable
 
 import pycrunch
 import scrunch.datasets
@@ -181,7 +187,7 @@ class Group(object):
     def _validate_alias_arg(alias):
         if isinstance(alias, six.string_types):
             alias = [alias]
-        if not isinstance(alias, collections.Iterable):
+        if not isinstance(alias, Iterable):
             raise ValueError(
                 'Invalid list of aliases/ids/groups to be inserted'
                 ' into the Group.'

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py36,py37,py38,py39,{py27,py36,py37,py38,py39}-pandas
+envlist = py27,py36,py37,py38,py39,py311{py27,py36,py37,py38,py39,py311}-pandas
 minversion = 2.4
 skip_missing_interpreters = true
 
@@ -10,6 +10,7 @@ python =
     3.7: py37,py37-pandas
     3.8: py38,py38-pandas
     3.9: py39,py39-pandas
+    3.11: py311,py311-pandas
 
 [testenv]
 deps =


### PR DESCRIPTION
As discussed in the issues section of the `scrunch` repository [here](https://github.com/Crunch-io/scrunch/issues/449), this Pull Request attempts to make `scrunch` compatible with the Python version `3.11`.

The adjustments are made only in the modules, `dataset.py`, `order.py` & `expressions.py`.

These include version specific checks for importing methods from the `collection` module and accessing of values of the `ast.Subscript` object.



|Python version| Test Result |
|--|--|
|2.7|![image](https://github.com/Crunch-io/scrunch/assets/88078876/e94ed7b2-1b7b-420e-9e66-f2bf3dbfabb2)|
|3.6|![image](https://github.com/Crunch-io/scrunch/assets/88078876/e97b595a-3bd9-4e5f-a7f0-590ceed06f76)|
|3.11|![image](https://github.com/Crunch-io/scrunch/assets/88078876/7869b219-0d8e-4d78-b676-802f05216027)|
