### PR TITLE
Show integers not floats for category

### DIFF
--- a/scrunch/expressions.py
+++ b/scrunch/expressions.py
@@ -846,6 +846,10 @@ def prettify(expr, ds=None):
                     # Must escape single-quote from string value
                     value = _quote_value(value)
 
+                if isinstance(value, float) and value.is_integer():
+                    # Check if the value is a float and if it can be exactly represented as an integer
+                    value = int(value)
+
                 return value
 
             return list(fragment.values())[0]

--- a/scrunch/expressions.py
+++ b/scrunch/expressions.py
@@ -756,6 +756,14 @@ def process_expr(obj, ds):
         return _process(copy.deepcopy(obj), variables)
 
 
+def clean_integer(value):
+    """It cleans values that are `floats` but can be integers"""
+    if isinstance(value, float) and value.is_integer():
+        # Check if the value is a float and if it can be exactly represented as an integer
+        value = int(value)
+    return value
+
+
 def prettify(expr, ds=None):
     """
     Translate the crunch expression dictionary to the string representation.
@@ -849,6 +857,9 @@ def prettify(expr, ds=None):
                 if isinstance(value, float) and value.is_integer():
                     # Check if the value is a float and if it can be exactly represented as an integer
                     value = int(value)
+
+                if isinstance(value, list):
+                    value = [clean_integer(v) for v in value]
 
                 return value
 

--- a/scrunch/tests/test_expressions.py
+++ b/scrunch/tests/test_expressions.py
@@ -2643,6 +2643,23 @@ class TestExpressionPrettify(TestCase):
         cel = prettify(expr)
         assert expected == cel
 
+    def test_float_conversion_to_integer(self):
+        expr = {
+            'function': '==',
+            'args': [
+                {
+                    'variable': 'age'
+                },
+                {
+                    'value': 25.0
+                }
+            ]
+        }
+
+        expected = 'age == 25'
+        cel = prettify(expr)
+        assert expected == cel
+
     def test_and(self):
         expr = {
             'function': 'and',

--- a/scrunch/tests/test_expressions.py
+++ b/scrunch/tests/test_expressions.py
@@ -2660,6 +2660,38 @@ class TestExpressionPrettify(TestCase):
         cel = prettify(expr)
         assert expected == cel
 
+    def test_float_conversion_integer_in_list(self):
+        expr = {
+            "function": "in",
+            "args": [
+                {
+                    "variable": "my_var"
+                },
+                {
+                    "value": [
+                        1.0, 2.0
+                    ]
+                }
+            ]
+        }
+        assert prettify(expr) == "my_var in [1, 2]"
+
+    def test_string_no_need_conversion_in_list(self):
+        expr = {
+            "function": "in",
+            "args": [
+                {
+                    "variable": "my_var"
+                },
+                {
+                    "value": [
+                        "test"
+                    ]
+                }
+            ]
+        }
+        assert prettify(expr) == "my_var in ['test']"
+
     def test_and(self):
         expr = {
             'function': 'and',


### PR DESCRIPTION
Now, when running prettify on expressions that has float values that are in fact integers, the return value is the integer.