### PR TITLE
fix pytest skipif wrong clause in integration/test_expressions

### DIFF
--- a/integration/test_dataset.py
+++ b/integration/test_dataset.py
@@ -47,7 +47,7 @@ class TestDatasetMethods(BaseIntegrationTestCase):
         finally:
             ds.delete()
 
-    @pytest.mark.skipif(os.environ.get("LOCAL_INTEGRATION") is not None, reason="Do not run this test during CI/CD")
+    @pytest.mark.skipif(os.environ.get("LOCAL_INTEGRATION") is None, reason="Do not run this test during CI/CD")
     def test_append_dataset(self):
         ds = self.site.datasets.create(as_entity({"name": "test_scrunch_append_dataset"})).refresh()
         ds.variables.create(
@@ -130,7 +130,7 @@ class TestDatasetMethods(BaseIntegrationTestCase):
             ds.delete()
             ds_to_append.delete()
 
-    @pytest.mark.skipif(os.environ.get("LOCAL_INTEGRATION") is not None, reason="Do not run this test during CI/CD")
+    @pytest.mark.skipif(os.environ.get("LOCAL_INTEGRATION") is None, reason="Do not run this test during CI/CD")
     def test_append_dataset_with_filter(self):
         ds = self.site.datasets.create(as_entity({"name": "test_scrunch_append_dataset"})).refresh()
         ds.variables.create(
@@ -227,7 +227,7 @@ class TestDatasetMethods(BaseIntegrationTestCase):
             ds.delete()
             ds_to_append.delete()
 
-    @pytest.mark.skipif(os.environ.get("LOCAL_INTEGRATION") is not None, reason="Do not run this test during CI/CD")
+    @pytest.mark.skipif(os.environ.get("LOCAL_INTEGRATION") is None, reason="Do not run this test during CI/CD")
     def test_append_dataset_with_filter_and_exclusion(self):
         ds = self.site.datasets.create(as_entity({"name": "test_scrunch_append_dataset_with_filter_exclusion"})).refresh()
         ds.variables.create(
@@ -325,7 +325,7 @@ class TestDatasetMethods(BaseIntegrationTestCase):
             ds.delete()
             ds_to_append.delete()
 
-    @pytest.mark.skipif(os.environ.get("LOCAL_INTEGRATION") is not None, reason="Do not run this test during CI/CD")
+    @pytest.mark.skipif(os.environ.get("LOCAL_INTEGRATION") is None, reason="Do not run this test during CI/CD")
     def test_append_dataset_with_variables_list_and_exclusion(self):
         ds = self.site.datasets.create(as_entity({"name": "test_scrunch_append_dataset_with_variable_exclusion"})).refresh()
         ds.variables.create(
@@ -422,7 +422,7 @@ class TestDatasetMethods(BaseIntegrationTestCase):
             ds.delete()
             ds_to_append.delete()
 
-    @pytest.mark.skipif(os.environ.get("LOCAL_INTEGRATION") is not None, reason="Do not run this test during CI/CD")
+    @pytest.mark.skipif(os.environ.get("LOCAL_INTEGRATION") is None, reason="Do not run this test during CI/CD")
     def test_append_dataset_with_variables_list_filters_and_exclusion(self):
         ds = self.site.datasets.create(as_entity({
             "name": "test_scrunch_append_dataset_with_variable_filters_exclusion"

--- a/integration/test_expressions.py
+++ b/integration/test_expressions.py
@@ -10,7 +10,7 @@ from fixtures import BaseIntegrationTestCase, MR_CATS
 from scrunch.mutable_dataset import get_mutable_dataset
 
 
-@pytest.mark.skipif(os.environ.get("LOCAL_INTEGRATION") is not None, reason="Do not run this test during CI/CD")
+@pytest.mark.skipif(os.environ.get("LOCAL_INTEGRATION") is None, reason="Do not run this test during CI/CD")
 class TestExpressions(BaseIntegrationTestCase):
 
     def _create_mr_dataset(self, name, rows):


### PR DESCRIPTION
The pytest.skipif decorator has the wrong condition. It is the opposite of what we want to do.
this PR is aims to fix that.