### PR TITLE
Allowing Project Paths to be passed to scrunch.dataset.fork() method

### DIFF
--- a/scrunch/datasets.py
+++ b/scrunch/datasets.py
@@ -2419,7 +2419,11 @@ class BaseDataset(ReadOnly, DatasetVariablesMixin):
 
         # not returning a dataset
         payload = shoji_entity_wrapper(body)
-        _fork = self.resource.forks.create(payload).refresh()
+        try:
+            _fork = dataset.resource.forks.create(payload).refresh()
+        except TaskProgressTimeoutError as exc:
+            _fork = exc.entity.wait_progress(exc.response).refresh()
+            
         # return a MutableDataset always
         fork_ds = MutableDataset(_fork)  # Fork has same editor as current user
         return fork_ds

--- a/scrunch/datasets.py
+++ b/scrunch/datasets.py
@@ -2392,7 +2392,7 @@ class BaseDataset(ReadOnly, DatasetVariablesMixin):
         :returns _fork: scrunch.datasets.BaseDataset
         """
         from scrunch.mutable_dataset import MutableDataset
-        
+
         description = description or self.resource.body.description
 
         if name is None:
@@ -2408,7 +2408,7 @@ class BaseDataset(ReadOnly, DatasetVariablesMixin):
             is_published=is_published,
             **kwargs
         )
-        
+       
         # Handling project vs owner conflict
         owner = kwargs.get("owner")
 
@@ -2432,15 +2432,7 @@ class BaseDataset(ReadOnly, DatasetVariablesMixin):
 
         payload = shoji_entity_wrapper(body)
 
-        try:
-            _fork = self.resource.forks.create(payload).refresh()
-        except TaskProgressTimeoutError as exc:
-            # To avoid getting another timeout,
-            # setting timeout=None & increasing the interval.
-            _fork = exc.entity.wait_progress(
-                exc.response,
-                progress_tracker=DefaultProgressTracking(timeout=None, interval=10)
-            ).refresh()
+        _fork = self.resource.forks.create(payload).refresh()
         return MutableDataset(_fork)
 
 

--- a/scrunch/datasets.py
+++ b/scrunch/datasets.py
@@ -2384,7 +2384,10 @@ class BaseDataset(ReadOnly, DatasetVariablesMixin):
         :param preserve_owner: bool, default=True
             If True, the owner of the fork will be the same as the parent
             dataset otherwise the owner will be the current user in the
-            session and the Dataset will be set under `Persona Project`
+            session and the Dataset will be set under `Personal Project`.
+        :kwargs owner: str (optional)
+            When preserve_owner=False, the owner of fork will be the set
+            according to the passed Project URL or Folder path.
 
         :returns _fork: scrunch.datasets.BaseDataset
         """

--- a/scrunch/datasets.py
+++ b/scrunch/datasets.py
@@ -2420,13 +2420,11 @@ class BaseDataset(ReadOnly, DatasetVariablesMixin):
         # not returning a dataset
         payload = shoji_entity_wrapper(body)
         try:
-            _fork = dataset.resource.forks.create(payload).refresh()
+            _fork = self.resource.forks.create(payload).refresh()
         except TaskProgressTimeoutError as exc:
             _fork = exc.entity.wait_progress(exc.response).refresh()
-            
-        # return a MutableDataset always
-        fork_ds = MutableDataset(_fork)  # Fork has same editor as current user
-        return fork_ds
+
+        return MutableDataset(_fork)
 
     def replace_values(self, variables, filter=None, literal_subvar=False, timeout=60):
         """

--- a/scrunch/datasets.py
+++ b/scrunch/datasets.py
@@ -2412,8 +2412,6 @@ class BaseDataset(ReadOnly, DatasetVariablesMixin):
         owner = kwargs.get("owner")
         if preserve_owner:
             body['owner'] = self.resource.body.owner
-            if owner:
-                LOG.warning("'owner' parameter is ignored when preserve_owner=True")
         elif owner:
             body["owner"] = (
                 owner if owner.startswith("http") else get_project(owner).url

--- a/scrunch/datasets.py
+++ b/scrunch/datasets.py
@@ -2402,7 +2402,6 @@ class BaseDataset(ReadOnly, DatasetVariablesMixin):
                 dsname = dsname.encode("ascii", "ignore")
             name = "FORK #{} of {}".format(nforks + 1, dsname)
 
-
         body = dict(
             name=name,
             description=description,
@@ -2421,7 +2420,7 @@ class BaseDataset(ReadOnly, DatasetVariablesMixin):
         elif owner:
             project = owner
         
-        # Setting project value based on presere_owner
+        # Setting project value based on preserve_owner.
         if preserve_owner and project:
             raise ValueError("Cannot pass 'project' or 'owner' when preserve_owner=True")
         elif preserve_owner:
@@ -2436,7 +2435,12 @@ class BaseDataset(ReadOnly, DatasetVariablesMixin):
         try:
             _fork = self.resource.forks.create(payload).refresh()
         except TaskProgressTimeoutError as exc:
-            _fork = exc.entity.wait_progress(exc.response).refresh()
+            # To avoid getting another timeout,
+            # setting timeout=None & increasing the interval.
+            _fork = exc.entity.wait_progress(
+                exc.response,
+                progress_tracker=DefaultProgressTracking(timeout=None, interval=10)
+            ).refresh()
         return MutableDataset(_fork)
 
 

--- a/scrunch/tests/test_datasets.py
+++ b/scrunch/tests/test_datasets.py
@@ -1819,6 +1819,8 @@ class TestForks(TestCase):
         err_msg2 = ("Cannot pass 'project' or 'owner' when preserve_owner=True")
         with pytest.raises(ValueError, match=err_msg2):
             ds.fork(preserve_owner=True, project="1234")
+            
+         with pytest.raises(ValueError, match=err_msg2):
             ds.fork(preserve_owner=True, owner="1234")
         
 

--- a/scrunch/tests/test_datasets.py
+++ b/scrunch/tests/test_datasets.py
@@ -1779,12 +1779,12 @@ class TestForks(TestCase):
 
 
     def test_fork_project(self):
-        project_id = 'https://test.crunch.io/api/projects/1234/'
+        project = 'https://test.crunch.io/api/projects/1234/'
         sess = MagicMock()
         body = JSONObject({
             'name': 'ds name',
             'description': 'ds description',
-            'owner': project_id,
+            'owner': project,
         })
         ds_res = MagicMock(session=sess, body=body)
         ds_res.forks = MagicMock()
@@ -1796,16 +1796,16 @@ class TestForks(TestCase):
             'body': {
                 'name': 'FORK #1 of ds name',
                 'description': 'ds description',
-                'owner': project_id,  # Project added
+                'owner': project,  # Project added
                 'is_published': False,
             }
         }
         # Using project parameter
-        ds.fork(preserve_owner=False, project=project_id)
+        ds.fork(preserve_owner=False, project=project)
         ds_res.forks.create.assert_called_with(expected_payload)
 
         # Using owner parameter
-        ds.fork(preserve_owner=False, owner=project_id)
+        ds.fork(preserve_owner=False, owner=project)
         ds_res.forks.create.assert_called_with(expected_payload)
 
         # Validations
@@ -1826,17 +1826,15 @@ class TestForks(TestCase):
 
 
     def test_fork_preserve_owner(self):
-        user_id = 'http://test.crunch.io/api/users/123/'
-        project_id = 'http://test.crunch.io/api/projects/123/'
+        project = 'http://test.crunch.io/api/projects/123/'
         sess = MagicMock()
         body = JSONObject({
             'name': 'ds name',
             'description': 'ds description',
-            'owner': project_id,
-            # 'owner': user_id,
+            'owner': project,
         })
         ds_res = MagicMock(session=sess, body=body)
-        ds_res.project.self = project_id
+        ds_res.project.self = project
         ds_res.forks = MagicMock()
         ds_res.forks.index = {}
         ds = BaseDataset(ds_res)
@@ -1846,8 +1844,7 @@ class TestForks(TestCase):
             'body': {
                 'name': 'FORK #1 of ds name',
                 'description': 'ds description',
-                # 'owner': user_id,  # Owner preserved
-                'owner': project_id,
+                'owner': project,  # Project preserved
                 'is_published': False,
             }
         })

--- a/scrunch/tests/test_datasets.py
+++ b/scrunch/tests/test_datasets.py
@@ -1820,7 +1820,7 @@ class TestForks(TestCase):
         with pytest.raises(ValueError, match=err_msg2):
             ds.fork(preserve_owner=True, project="1234")
             
-         with pytest.raises(ValueError, match=err_msg2):
+        with pytest.raises(ValueError, match=err_msg2):
             ds.fork(preserve_owner=True, owner="1234")
         
 


### PR DESCRIPTION
The `owner` parameter of the `fork()` method allows creating a dataset fork in a defined project location.
But to make it work the `owner` parameter _always_ needs to be the Project URL e.g., `https://<company>.crunch.io/api/projects/<project_id>/`.

This often requires the user, an additional step, to manually find out the project URL to pass as the `owner` parameter.

It is comparatively easier to work with the project folder paths e.g., `"Client datasets | Projects A | Project A - 1 "` than the project URL, which also is more human friendly.
Hence, this Pull Request adds a new feature to `fork()` method to allow the user to pass the project path to the `owner` parameter as well, as requested in the [issue](https://github.com/Crunch-io/scrunch/issues/464).

The previous functionality of the `fork()` method is still the same, only the behavior of the `owner` parameter has been updated.

On passing project path (instead of a project URL), the `fork()` method now automatically maps the folder path to its respective Project URL. Thus, preventing the user an additional step for finding out the Project URL manually.


Examples:
```
import scrunch

ds = scrunch.get_dataset("Dataset X", project="Project A")

# Passing project path to `owner`
ds_fork = ds.fork(preserve_owner=False, owner="Project B | Project 1")


# Passing project URL to `owner`
ds_fork = ds.fork(preserve_owner=False, owner="https://<company>.crunch.io/api/projects/<project_id>/")

```

Additionally, this PR handles the timeout error (`TaskProgressTimeoutError`) which often occurs when forking large datasets.