### PR TITLE
[188043638] add pre commit hok

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,6 +1,0 @@
-[run]
-omit = scrunch/tests/*
-
-
-[report]
-show_missing = True

--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,7 @@ pip-delete-this-directory.txt
 htmlcov/
 .tox/
 .coverage
+.coveragerc
 .coverage.*
 .cache
 nosetests.xml

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,6 @@ repos:
     hooks:
       # Run the linter.
       - id: ruff
-
       # Run the formatter.
       - id: ruff-format
         args: ["--check"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,6 +19,7 @@ repos:
   - repo: local
     hooks:
       - id: pytest-check
+        stages: [ push ]
         name: pytest-check
         entry: pytest scrunch/tests
         language: python

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,28 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v2.3.0
+    hooks:
+      - id: debug-statements
+        stages: [ commit ]
+      - id: end-of-file-fixer
+        stages: [ commit ]
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    # Ruff version.
+    rev: v0.6.1
+    hooks:
+      # Run the linter.
+      - id: ruff
+
+      # Run the formatter.
+      - id: ruff-format
+        args: ["--check"]
+
+  - repo: local
+    hooks:
+      - id: pytest-check
+        name: pytest-check
+        entry: pytest scrunch/tests
+        language: python
+        pass_filenames: false
+        always_run: true
+        types: [python]

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,76 @@
+# Exclude a variety of commonly ignored directories.
+exclude = [
+    ".bzr",
+    ".direnv",
+    ".eggs",
+    ".git",
+    ".git-rewrite",
+    ".hg",
+    ".ipynb_checkpoints",
+    ".mypy_cache",
+    ".nox",
+    ".pants.d",
+    ".pyenv",
+    ".pytest_cache",
+    ".pytype",
+    ".ruff_cache",
+    ".svn",
+    ".tox",
+    ".venv",
+    ".vscode",
+    "__pypackages__",
+    "_build",
+    "buck-out",
+    "build",
+    "dist",
+    "node_modules",
+    "site-packages",
+    "venv",
+]
+
+# Same as Black.
+line-length = 88
+indent-width = 4
+
+target-version = "py311"
+
+[lint]
+# Enable Pyflakes (`F`) and a subset of the pycodestyle (`E`)  codes by default.
+# Unlike Flake8, Ruff doesn't enable pycodestyle warnings (`W`) or
+# McCabe complexity (`C901`) by default.
+select = ["E4", "E7", "E9", "F"]
+ignore = []
+
+# Allow fix for all enabled rules (when `--fix`) is provided.
+fixable = ["ALL"]
+unfixable = []
+
+# Allow unused variables when underscore-prefixed.
+dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
+
+[format]
+# Like Black, use double quotes for strings.
+quote-style = "double"
+
+# Like Black, indent with spaces, rather than tabs.
+indent-style = "space"
+
+# Like Black, respect magic trailing commas.
+skip-magic-trailing-comma = false
+
+# Like Black, automatically detect the appropriate line ending.
+line-ending = "auto"
+
+# Enable auto-formatting of code examples in docstrings. Markdown,
+# reStructuredText code/literal blocks and doctests are all supported.
+#
+# This is currently disabled by default, but it is planned for this
+# to be opt-out in the future.
+docstring-code-format = false
+
+# Set the line length limit used when formatting code snippets in
+# docstrings.
+#
+# This only has an effect when the `docstring-code-format` setting is
+# enabled.
+docstring-code-line-length = "dynamic"

--- a/ruff.toml
+++ b/ruff.toml
@@ -26,6 +26,8 @@ exclude = [
     "node_modules",
     "site-packages",
     "venv",
+    "COPYING",
+    "COPYING.LESSER"
 ]
 
 # Same as Black.
@@ -38,7 +40,7 @@ target-version = "py311"
 # Enable Pyflakes (`F`) and a subset of the pycodestyle (`E`)  codes by default.
 # Unlike Flake8, Ruff doesn't enable pycodestyle warnings (`W`) or
 # McCabe complexity (`C901`) by default.
-select = ["E4", "E7", "E9", "F"]
+select = ["E4", "E7", "E9", "F", "I"]
 ignore = []
 
 # Allow fix for all enabled rules (when `--fix`) is provided.


### PR DESCRIPTION
This PR wants to add pre-commit hooks to improve the codebase and checks for errors. 
This is intended to be run using python3.11 so that we start moving to a newer version of python. 
However, the precommit hooks does not change the files in a way that the py2 version is not working.

How to reproduce:
1. `pip install pre-commit`
2. `pre-commit install`
3. `pre-commit run --all-files` to see that the hook is working

There are some checks that are run during commit:

- debug statements
- end of file fixer
- ruff linter and formatter (with --check flag so that no changes are made in the files)

On push, we run the tests with pytest.

I am going to create another PR to fix all the error that are highlighted when running pre-commit run --all-files.