### PR TITLE
Removing version pinning for requests library

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ params = dict(
     python_requires='>=2.7',
     install_requires=[
         "pycrunch==0.5.5",
-        "requests==2.27.0",
+        "requests",
         crunch_cube,
         'six',
     ],

--- a/setup.py
+++ b/setup.py
@@ -26,9 +26,11 @@ pkg_resources "managed" namespace packages?
 """
 
 crunch_cube = "cr.cube"
+requests = "requests"
 
 if PY2:
     crunch_cube = "cr.cube==2.3.9"
+    requests = "requests==2.27.0"
 
 params = dict(
     name=name,
@@ -47,7 +49,7 @@ params = dict(
     python_requires='>=2.7',
     install_requires=[
         "pycrunch==0.5.5",
-        "requests",
+        requests,
         crunch_cube,
         'six',
     ],


### PR DESCRIPTION
In this PR, we've removed the version pinning for `request` library in order to be able to use it's latest version.