### PR TITLE
Task/update fork method preserve owner parameter

### DIFF
--- a/scrunch/datasets.py
+++ b/scrunch/datasets.py
@@ -2379,10 +2379,19 @@ class BaseDataset(ReadOnly, DatasetVariablesMixin):
 
         :returns _fork: scrunch.datasets.BaseDataset
         """
-
         from scrunch.mutable_dataset import MutableDataset
+        
+        # Handling project vs owner conflict
+        owner = kwargs.get("owner")
 
-        description = description or self.resource.body.description
+        if project and owner:
+            raise ValueError(
+                "Cannot pass both 'project' & 'owner' parameters together. "
+                "Please try again by passing only 'project' parameter."
+        )
+        elif owner:
+            project = owner
+            del kwargs["owner"]
 
         LOG.warning(
             "The preserve_owner parameter will be removed soon"
@@ -2400,22 +2409,10 @@ class BaseDataset(ReadOnly, DatasetVariablesMixin):
 
         body = dict(
             name=name,
-            description=description,
+            description=description or self.resource.body.description,
             is_published=is_published,
             **kwargs
         )
-
-        # Handling project vs owner conflict
-        owner = kwargs.get("owner")
-
-        if project and owner:
-            raise ValueError(
-                "Cannot pass both 'project' & 'owner' parameters together. "
-                "Please try again by passing only 'project' parameter."
-        )
-        elif owner:
-            project = owner
-
         # Setting project value based on preserve_owner.
         if preserve_owner:
             if project:
@@ -2424,7 +2421,7 @@ class BaseDataset(ReadOnly, DatasetVariablesMixin):
                 )
             else:
                 # Create fork in source dataset path.
-                body["project"] = self.resource.body.owner
+                body["project"] = self.resource.body.owner 
         else:
             if project:
                 # Create fork in given Project path.
@@ -3510,5 +3507,5 @@ class BackfillFromCSV:
                 if folder_name in folders_by_name:
                     folders_by_name[folder_name].entity.delete()
                 # Always delete the tmp dataset no matter what
-                tmp_ds.delete()
+                tmp_ds.delete)
 

--- a/scrunch/datasets.py
+++ b/scrunch/datasets.py
@@ -2424,11 +2424,11 @@ class BaseDataset(ReadOnly, DatasetVariablesMixin):
                 )
             else:
                 # Create fork in source dataset path.
-                body["owner"] = self.resource.body.owner
+                body["project"] = self.resource.body.owner
         else:
             if project:
                 # Create fork in given Project path.
-                body["owner"] = (
+                body["project"] = (
                     project if project.startswith("http") else get_project(project).url
                 )
             else:

--- a/scrunch/datasets.py
+++ b/scrunch/datasets.py
@@ -2402,7 +2402,13 @@ class BaseDataset(ReadOnly, DatasetVariablesMixin):
                 dsname = dsname.encode("ascii", "ignore")
             name = "FORK #{} of {}".format(nforks + 1, dsname)
 
-        body = dict(name=name, description=description, is_published=is_published, **kwargs)
+        body = dict(
+            name=name,
+            description=description,
+            is_published=is_published,
+            **kwargs
+        )
+
         # Handling project vs owner conflict
         owner = kwargs.get("owner")
 
@@ -2410,7 +2416,7 @@ class BaseDataset(ReadOnly, DatasetVariablesMixin):
             raise ValueError(
                 "Cannot pass both 'project' & 'owner' parameters together. "
                 "Please try again by passing only 'project' parameter."
-            )
+        )
         elif owner:
             project = owner
 
@@ -2435,6 +2441,7 @@ class BaseDataset(ReadOnly, DatasetVariablesMixin):
                 )
 
         payload = shoji_entity_wrapper(body)
+
         _fork = self.resource.forks.create(payload).refresh()
         return MutableDataset(_fork)
 

--- a/scrunch/datasets.py
+++ b/scrunch/datasets.py
@@ -2351,15 +2351,8 @@ class BaseDataset(ReadOnly, DatasetVariablesMixin):
         new_deck = self.resource.decks.create(payload)
         return self.decks[new_deck.self.split('/')[-2]]
 
-    def fork(
-        self,
-        description=None,
-        name=None,
-        is_published=False,
-        preserve_owner=True,
-        project=None,
-        **kwargs
-    ):
+    def fork(self, description=None, name=None, is_published=False,
+        preserve_owner=True, project=None, **kwargs):
         """
         Create a fork of ds and add virgin savepoint.
 

--- a/scrunch/datasets.py
+++ b/scrunch/datasets.py
@@ -3507,5 +3507,5 @@ class BackfillFromCSV:
                 if folder_name in folders_by_name:
                     folders_by_name[folder_name].entity.delete()
                 # Always delete the tmp dataset no matter what
-                tmp_ds.delete)
+                tmp_ds.delete()
 

--- a/scrunch/datasets.py
+++ b/scrunch/datasets.py
@@ -2420,6 +2420,8 @@ class BaseDataset(ReadOnly, DatasetVariablesMixin):
                 raise ValueError(
                     "Cannot pass 'project' or 'owner' when preserve_owner=True."
                 )
+            else:
+                body["owner"] = self.resource.body.owner
         else:
             if project:
                 body["owner"] = (

--- a/scrunch/datasets.py
+++ b/scrunch/datasets.py
@@ -2367,12 +2367,13 @@ class BaseDataset(ReadOnly, DatasetVariablesMixin):
             If True, the fork will be visible to viewers of ds. If False it
             will only be viewable to editors of ds.
         :param preserve_owner: bool, default=True
-            If True, the owner of the fork will be the same as the parent
-            dataset otherwise the owner will be the current user in the
-            session and the Dataset will be set under `Personal Project`.
+            If preserve_owner=True and project=None, the fork dataset will
+            be created in the same location as source dataset.
+            If preserve_owner=False and project is passed, the fork dataset
+            will be created in the given project location.
         :param project: str, default=None
-            The project ID or URL for the project in which the fork
-            dataset should be created.
+            The project ID or URL for the project in which the fork dataset
+            should be created.
             If project=None, the fork dataset will be created in the same
             location as the source dataset.
 

--- a/scrunch/datasets.py
+++ b/scrunch/datasets.py
@@ -2373,6 +2373,8 @@ class BaseDataset(ReadOnly, DatasetVariablesMixin):
         :param project: str, default=None
             The project ID or URL for the project in which the fork
             dataset should be created.
+            If project=None, the fork dataset will be created in the same
+            location as the source dataset.
 
         :returns _fork: scrunch.datasets.BaseDataset
         """

--- a/scrunch/datasets.py
+++ b/scrunch/datasets.py
@@ -2421,9 +2421,11 @@ class BaseDataset(ReadOnly, DatasetVariablesMixin):
                     "Cannot pass 'project' or 'owner' when preserve_owner=True."
                 )
             else:
+                # Create fork in source dataset path.
                 body["owner"] = self.resource.body.owner
         else:
             if project:
+                # Create fork in given Project path.
                 body["owner"] = (
                     project if project.startswith("http") else get_project(project).url
                 )

--- a/scrunch/tests/test_datasets.py
+++ b/scrunch/tests/test_datasets.py
@@ -1756,7 +1756,7 @@ class TestForks(TestCase):
         body = JSONObject({
             'name': 'ds name',
             'description': 'ds description',
-            'owner': 'http://test.crunch.io/api/users/123/',
+            'project': 'http://test.crunch.io/api/users/123/',
             'streaming': 'yes',
         })
         fork_res = MagicMock()
@@ -1786,7 +1786,7 @@ class TestForks(TestCase):
         body = JSONObject({
             'name': 'ds name',
             'description': 'ds description',
-            'owner': project,
+            'project': project,
         })
         ds_res = MagicMock(session=sess, body=body)
         ds_res.forks = MagicMock()
@@ -1833,7 +1833,7 @@ class TestForks(TestCase):
             {
                 "name": "ds name",
                 "description": "ds description",
-                "owner": project,
+                "project": project,
             }
         )
         ds_res = MagicMock(session=sess, body=body)

--- a/scrunch/tests/test_datasets.py
+++ b/scrunch/tests/test_datasets.py
@@ -1771,7 +1771,6 @@ class TestForks(TestCase):
         ds_res.forks.create.side_effect = _create
         ds = StreamingDataset(ds_res)
         forked_ds = ds.fork(preserve_owner=True)
-
         assert isinstance(forked_ds, MutableDataset)
         ds_res.forks.create.assert_called_with(as_entity({
             'name': 'FORK #1 of ds name',

--- a/scrunch/tests/test_datasets.py
+++ b/scrunch/tests/test_datasets.py
@@ -1777,6 +1777,8 @@ class TestForks(TestCase):
             'name': 'FORK #1 of ds name',
             'description': 'ds description',
             'is_published': False,
+            'owner': 'http://test.crunch.io/api/users/123/',
+
         }))
 
 

--- a/scrunch/tests/test_datasets.py
+++ b/scrunch/tests/test_datasets.py
@@ -1752,7 +1752,6 @@ class TestForks(TestCase):
 
     def test_fork(self):
         user_url = "some_user_url"
-
         sess = MagicMock()
         body = JSONObject({
             'name': 'ds name',

--- a/scrunch/tests/test_datasets.py
+++ b/scrunch/tests/test_datasets.py
@@ -1775,7 +1775,7 @@ class TestForks(TestCase):
             'name': 'FORK #1 of ds name',
             'description': 'ds description',
             'is_published': False,
-            'owner': 'http://test.crunch.io/api/users/123/',
+            'project': 'http://test.crunch.io/api/users/123/',
 
         }))
 
@@ -1798,7 +1798,7 @@ class TestForks(TestCase):
             'body': {
                 'name': 'FORK #1 of ds name',
                 'description': 'ds description',
-                'owner': project,  # Project added
+                'project': project,  # Project added
                 'is_published': False,
             }
         }
@@ -1856,7 +1856,7 @@ class TestForks(TestCase):
                 "body": {
                     "name": "FORK #1 of ds name",
                     "description": "ds description",
-                    "owner": project,  # Project preserved
+                    "project": project,  # Project preserved
                     "is_published": False,
                 },
             }

--- a/scrunch/tests/test_datasets.py
+++ b/scrunch/tests/test_datasets.py
@@ -1756,7 +1756,7 @@ class TestForks(TestCase):
         body = JSONObject({
             'name': 'ds name',
             'description': 'ds description',
-            'project': 'http://test.crunch.io/api/users/123/',
+            'owner': 'http://test.crunch.io/api/users/123/',
             'streaming': 'yes',
         })
         fork_res = MagicMock()
@@ -1786,7 +1786,7 @@ class TestForks(TestCase):
         body = JSONObject({
             'name': 'ds name',
             'description': 'ds description',
-            'project': project,
+            'owner': project,
         })
         ds_res = MagicMock(session=sess, body=body)
         ds_res.forks = MagicMock()
@@ -1833,7 +1833,7 @@ class TestForks(TestCase):
             {
                 "name": "ds name",
                 "description": "ds description",
-                "project": project,
+                "owner": project,
             }
         )
         ds_res = MagicMock(session=sess, body=body)


### PR DESCRIPTION
As informed by Crunch team, the special properties of the "Personal" folder are about to be replaced with a regular project folder that behaves like any other Crunch folder, at some point approaching the end of CY 2024. 

Recently added functionality to create a fork in a target location will still allow to use `preserve_owner` and hence might lead to creating the fork in either the "Personal" folder or keeping the source dataset's location. 

This MR proactively attempts to push towards the best-practice approach here by updating the fork method.
The behaviour of the preserve_owner parameter has been updated as described below:

- If `preserve_owner=False` and a project is not provided, we want to raise and indicate that an explicit project location is expected.
- If `preserve_owner=False` and a project is provided, this is consistent with what we want to acheive and the code can be executed as is.
- If `preserve_owner=True` and a project is provided, raise and indicate that this combination is ambiguous, only one of the two can be used AND that preserve_owner will be deprecated soon.
- Regardless of the value given to `preserve_owner`, log a `DeprecationWarning` that the `preserve_owner` parameter will be removed soon in favour of providing a project or not (in which case the behavior will be as it is currently if `preserve_owner=True and project=None`).

|Project passed|Preserve_owner = True|
|-|-|
|Yes| ![image](https://github.com/user-attachments/assets/aaaa51c4-15f8-482f-921c-2e08469d091c)|
|No| ![image](https://github.com/user-attachments/assets/b2466811-e317-4871-bd6a-e7fa18298807)|


|Project passed| Preserve_owner = False|
|-|-|
|Yes| ![image](https://github.com/user-attachments/assets/12214682-b4a2-4e26-a3e3-f2906c05162c)|
|No| ![image](https://github.com/user-attachments/assets/cd7ffcab-a60f-4698-9b4b-2401d8f04643)|
