### PR TITLE
Fixing docsting for fork function

### DIFF
--- a/scrunch/datasets.py
+++ b/scrunch/datasets.py
@@ -2372,7 +2372,8 @@ class BaseDataset(ReadOnly, DatasetVariablesMixin):
             If preserve_owner=False and project is passed, the fork dataset
             will be created in the given project location.
         :param project: str, default=None
-            The project ID or path where the fork dataset should be created.
+            The project ID or project path where the fork dataset should be
+            created.
             If project=None, the fork dataset will be created in the same
             location as the source dataset.
 

--- a/scrunch/datasets.py
+++ b/scrunch/datasets.py
@@ -2372,8 +2372,7 @@ class BaseDataset(ReadOnly, DatasetVariablesMixin):
             If preserve_owner=False and project is passed, the fork dataset
             will be created in the given project location.
         :param project: str, default=None
-            The project ID or URL for the project in which the fork dataset
-            should be created.
+            The project ID or path where the fork dataset should be created.
             If project=None, the fork dataset will be created in the same
             location as the source dataset.
 


### PR DESCRIPTION
In this pull request, the docstring for the `fork` function has been revised to accurately reflect the recent updates, which now permits the use of project `ID`s in lieu of URLs. This enhancement aims to improve clarity & usability for users and developers utilizing this function.