### PR TITLE
[ZC-1342]: Disable variable syntax in derivations

### DIFF
--- a/scrunch/datasets.py
+++ b/scrunch/datasets.py
@@ -1114,7 +1114,7 @@ class BaseDataset(ReadOnly, DatasetVariablesMixin):
             * In the case of a default category, it should indicate:
                 {"case": "else", "name": "Cat Name", "missing": <bool>, "id": <int cat code>}
 
-        :param variables: list of dictionaries with an `variable` and `case`
+        :param variables: list of dictionaries with `variable` and `case`
         :param name: Name of the new variable
         :param alias: Alias of the new variable
         :param description: Description of the new variable
@@ -1128,10 +1128,13 @@ class BaseDataset(ReadOnly, DatasetVariablesMixin):
         else_case = else_case[0] if else_case else {}
         variables = [c for c in variables if c["case"] != "else"]
 
-        if "variable" in else_case and "name" in else_case:
+        if ("variable" in else_case or "var" in else_case) and "name" in else_case:
             raise ValueError("Else case can be either variable or category not both")
 
-        aliases = {c["var"] for c in variables}
+        def _fill_variable_alias(case):
+            return case.get("var", case["variable"])
+
+        aliases = {_fill_variable_alias(c) for c in variables}
         vars_by_alias = self.resource.variables.by("alias")
         types = {vars_by_alias[al]["type"] for al in aliases}
         if types != {"categorical"}:
@@ -1164,13 +1167,13 @@ class BaseDataset(ReadOnly, DatasetVariablesMixin):
             })
 
         expr = {"function": "case", "args": args}
-        fill_map = {str(cid): {"var": v["var"]}
+        fill_map = {str(cid): {"var": _fill_variable_alias(v)}
                     for cid, v in zip(cat_ids, variables)}
 
-        if "var" in else_case:
+        if "var" in else_case or "variable" in else_case:
             # We are in the case of a default fill, replace the -1 with the new
             # variable
-            fill_map["-1"] = {"var": else_case["var"]}
+            fill_map["-1"] = {"var": _fill_variable_alias(else_case)}
 
         fill_expr = {
             "function": "fill",
@@ -1263,7 +1266,7 @@ class BaseDataset(ReadOnly, DatasetVariablesMixin):
             'function': 'rollup',
             'args': [
                 {
-                    'variable': self[variable_alias].url
+                    'var': variable_alias
                 },
                 {
                     'value': resolution
@@ -1450,7 +1453,7 @@ class BaseDataset(ReadOnly, DatasetVariablesMixin):
             subvar_name = subvar.get("name", subvar.get("alias")) or sv_code
             subreferences.append({"alias": sv_code, "name": subvar_name})
 
-        array_map = {v['id']: {'variable': self.get_url_by_alias(v['alias'])} for v in subvariables}
+        array_map = {v['id']: {'var': v['alias']} for v in subvariables}
         expression = {
             'function': 'array',
             'args': [{'function': 'make_frame', 'args': [{'map': array_map}]}],
@@ -1796,7 +1799,7 @@ class BaseDataset(ReadOnly, DatasetVariablesMixin):
             derivation = {
                 'function': 'copy_variable',
                 'args': [{
-                    'variable': variable_resource.self
+                    'var': variable.alias
                 }]
             }
             payload = shoji_entity_wrapper({
@@ -1907,7 +1910,7 @@ class BaseDataset(ReadOnly, DatasetVariablesMixin):
             'alias': alias,
             'description': description,
             'derivation': combine_responses_expr(
-                variable.resource.self, responses)
+                parent_alias, responses)
         })
         return self._var_create_reload_return(payload)
 
@@ -2798,7 +2801,7 @@ class BaseDataset(ReadOnly, DatasetVariablesMixin):
                 if fsum(val.values()) != 1.0:
                     raise ValueError('Weights for target {} need to add up to 1.0'.format(key))
                 _targets.append({
-                    'variable': self[key].id,
+                    'var': key,
                     'targets': list(map(list, val.items()))
                 })
 

--- a/scrunch/datasets.py
+++ b/scrunch/datasets.py
@@ -1131,7 +1131,7 @@ class BaseDataset(ReadOnly, DatasetVariablesMixin):
         if "variable" in else_case and "name" in else_case:
             raise ValueError("Else case can be either variable or category not both")
 
-        aliases = {c["variable"] for c in variables}
+        aliases = {c["var"] for c in variables}
         vars_by_alias = self.resource.variables.by("alias")
         types = {vars_by_alias[al]["type"] for al in aliases}
         if types != {"categorical"}:
@@ -1164,13 +1164,13 @@ class BaseDataset(ReadOnly, DatasetVariablesMixin):
             })
 
         expr = {"function": "case", "args": args}
-        fill_map = {str(cid): {"variable": vars_by_alias[v["variable"]]["id"]}
+        fill_map = {str(cid): {"var": v["var"]}
                     for cid, v in zip(cat_ids, variables)}
 
-        if "variable" in else_case:
+        if "var" in else_case:
             # We are in the case of a default fill, replace the -1 with the new
             # variable
-            fill_map["-1"] = {"variable": vars_by_alias[else_case["variable"]]["id"]}
+            fill_map["-1"] = {"var": else_case["var"]}
 
         fill_expr = {
             "function": "fill",
@@ -1875,7 +1875,7 @@ class BaseDataset(ReadOnly, DatasetVariablesMixin):
             'alias': alias,
             'description': description,
             'derivation': combine_categories_expr(
-                variable.resource.self, combinations)
+                variable.alias, combinations)
         })
         return self._var_create_reload_return(payload)
 

--- a/scrunch/datasets.py
+++ b/scrunch/datasets.py
@@ -1128,13 +1128,10 @@ class BaseDataset(ReadOnly, DatasetVariablesMixin):
         else_case = else_case[0] if else_case else {}
         variables = [c for c in variables if c["case"] != "else"]
 
-        if ("variable" in else_case or "var" in else_case) and "name" in else_case:
+        if "variable" in else_case and "name" in else_case:
             raise ValueError("Else case can be either variable or category not both")
 
-        def _fill_variable_alias(case):
-            return case.get("var", case["variable"])
-
-        aliases = {_fill_variable_alias(c) for c in variables}
+        aliases = {c["variable"] for c in variables}
         vars_by_alias = self.resource.variables.by("alias")
         types = {vars_by_alias[al]["type"] for al in aliases}
         if types != {"categorical"}:
@@ -1167,13 +1164,13 @@ class BaseDataset(ReadOnly, DatasetVariablesMixin):
             })
 
         expr = {"function": "case", "args": args}
-        fill_map = {str(cid): {"var": _fill_variable_alias(v)}
+        fill_map = {str(cid): {"var": v["variable"]}
                     for cid, v in zip(cat_ids, variables)}
 
-        if "var" in else_case or "variable" in else_case:
+        if "variable" in else_case:
             # We are in the case of a default fill, replace the -1 with the new
             # variable
-            fill_map["-1"] = {"var": _fill_variable_alias(else_case)}
+            fill_map["-1"] = {"var": else_case["variable"]}
 
         fill_expr = {
             "function": "fill",

--- a/scrunch/expressions.py
+++ b/scrunch/expressions.py
@@ -510,14 +510,14 @@ def adapt_multiple_response(var_alias, values, vars_by_alias):
     if all(isinstance(value, int) for value in values):
         # scenario var.any([1])
         column = values
-        subvars = list(aliases)
+        subvars = sorted(aliases)
     else:
         # scenario var.any([subvar1, subvar2])
         # in this scenario, we only want category ids that refers to `selected` categories
         column = [
             cat.get("id") for cat in _get_categories_from_var_index(vars_by_alias, var_alias) if cat.get("selected")
         ]
-        subvars = [sva for sva in aliases if sva in values]
+        subvars = [sva for sva in values if sva in aliases]
 
     for sva in subvars:
         result.append({

--- a/scrunch/expressions.py
+++ b/scrunch/expressions.py
@@ -12,7 +12,7 @@ be transformed by this module's parser into:
                     'function': '==',
                     'args': [
                         {
-                            'variable': 'disposition'
+                            'var': 'disposition'
                         },
                         {
                             'value': 0
@@ -23,7 +23,7 @@ be transformed by this module's parser into:
                     'function': '==',
                     'args': [
                         {
-                            'variable': 'exit_status'
+                            'var': 'exit_status'
                         },
                         {
                             'value': 0
@@ -33,11 +33,12 @@ be transformed by this module's parser into:
             ]
         }
 
-Its important to note that the expression objects produced by this module's
-parser are not ready for being sent to crunch, as they refer to variables
-by `alias` rather than by `variable_id` (which is a URL). So, this module
-also provides a `process_expr` function that creates an expression object
-ready for the crunch API.
+Expression objects produced by `parse_expr` are purely syntactic: they
+refer to variables by `alias` (in `var` terms) and know nothing about
+the dataset. They are not yet ready to be sent to Crunch -- the API still
+needs some metadata-driven rewrites (subvariable -> parent+axes, category
+name -> id, array variable expansion, etc.). Those rewrites are applied
+by `process_expr` in a second pass, given a dataset entity.
 """
 
 import ast
@@ -549,24 +550,38 @@ def _update_values_for_multiple_response(new_values, values, subitem, vars_by_al
 
 def process_expr(obj, ds):
     """
-    Given a Crunch expression object (or objects) and a Dataset entity object
-    (i.e. a Shoji entity), this function returns a tuple, the first element is
-    new expression object (or a list of new expression objects) with all
-    variable aliases transformed into variable URLs and the second element
-    of the tuple is a flag indicating if the expressions needs nesting/wrapping
-    in `or` functions (for the case when an array variable is passed).
+    Apply dataset metadata to a parsed expression so it is ready for the
+    Crunch API.
+
+    `parse_expr` produces a syntactic, AST-level expression that knows
+    nothing about the dataset. This function takes that expression plus a
+    dataset entity and applies the metadata-driven rewrites the API
+    requires:
+
+      1. Subvariable -> parent + axes: `{'var': sub_alias}` becomes
+         `{'var': parent_alias, 'axes': [sub_alias]}`.
+      2. Category name -> id: `disposition == 'Complete'` becomes
+         `disposition == <id>` using the variable's category list.
+      3. Multiple-response adaptation: filters against MR variables are
+         rewritten into the array-level `column` form.
+      4. `any` <-> `in` swap: the API wants `in` for categorical `.any()`
+         and `any` for array `.in()` calls.
+      5. Array variable expansion: `Q2.any([1,2,3])` over an array gets
+         expanded into an `or(...)` chain over its subvariables.
+
+    Aliases are NOT converted to URLs -- the API accepts alias-based `var`
+    terms directly. Alias existence is validated here as a side-effect of
+    the metadata lookups.
     """
 
-    base_url = ds.self
     variables = get_dataset_variables(ds)
     var_index = ds.variables.index
 
     def ensure_category_ids(subitems, values, arrays, variables=variables):
-        var_id = None
+        """Replace category-name strings in value args with their numeric
+        ids using the variable's category metadata. Multiple-response args
+        are delegated to `adapt_multiple_response`."""
         _subitems = []
-
-        def variable_id(variable_url):
-            return variable_url.split('/')[-2]
 
         def category_ids(var_alias, var_value, variables=variables):
             value = None
@@ -609,7 +624,9 @@ def process_expr(obj, ds):
                 return var_value
             return value
 
-        # special case for multiple_response variables
+        # MR special case: when the args look like (<var>, <value>) and the
+        # variable is multiple_response, delegate to the MR adapter which
+        # rewrites the filter into the array-level `column` form.
         if len(subitems) == 2:
             _variable, _value = subitems
             var_alias = _variable.get('var')
@@ -618,10 +635,11 @@ def process_expr(obj, ds):
                 vars_by_alias = {v['alias']: v for _, v in var_index.items()}
                 if var_alias in vars_by_alias and vars_by_alias[var_alias]['type'] == 'multiple_response':
                     result = adapt_multiple_response(var_alias, _value[_value_key], vars_by_alias)
-                    # handle the multiple response type
                     _update_values_for_multiple_response(result[0], values, subitems[0], vars_by_alias, arrays)
                     return result
 
+        # General case: replace category names with their ids inside each
+        # value arg.
         for item in subitems:
             if isinstance(item, dict) and 'value' in item:
                 item['value'] = category_ids(var_alias, item['value'])
@@ -629,18 +647,86 @@ def process_expr(obj, ds):
 
         return _subitems, True
 
+    def _expand_array_filter(obj, op, array_var, arrays, values):
+        """Expand a filter against an array variable across its
+        subvariables. `Q2.any([1,2,3])` over an array with subvariables
+        sv1, sv2 becomes `or(sv1 in [1,2,3], sv2 in [1,2,3])`. With a
+        single subvariable, just emit the per-subvariable call directly.
+        For `is_valid` / `is_missing` (no value arg), only the function
+        name is swapped."""
+        if len(arrays) != 1:
+            raise ValueError
+
+        # Map the public op to the per-subvariable op + the wrapper used
+        # when expanding across multiple subvariables.
+        real_op = 'in'
+        expansion_op = 'or'
+        if op == 'all':
+            real_op = '=='
+            expansion_op = 'and'
+        elif op == 'is_valid':
+            real_op = 'all_valid'
+        elif op == 'is_missing':
+            real_op = 'is_missing'
+
+        if op in ('is_valid', 'is_missing'):
+            if len(values) != 0:
+                raise ValueError
+            obj['function'] = real_op
+            return obj
+
+        if len(values) != 1:
+            raise ValueError
+
+        subvariables = arrays[0]
+        value = values[0]
+
+        # `all` is one-value: unwrap the singleton list/column into a scalar.
+        if op == 'all':
+            inner_value = value.get("value", value.get("column", []))
+            if len(inner_value) != 1:
+                raise ValueError
+            value.pop("column", None)
+            value['value'] = inner_value[0]
+
+        if len(subvariables) == 1:
+            obj['function'] = real_op
+            obj['args'] = [
+                {
+                    'var': array_var['alias'],
+                    'axes': [array_var['subreferences'][subvariables[0]]['alias']]
+                },
+                value
+            ]
+            return obj
+
+        return {
+            'function': expansion_op,
+            'args': [
+                {
+                    'function': real_op,
+                    'args': [
+                        {'var': array_var['alias'], 'axes': [array_var['subreferences'][subvar]['alias']]},
+                        value
+                    ]
+                } for subvar in subvariables
+            ]
+        }
+
     def _process(obj, variables):
         op = None
         arrays = []
         values = []
-        subvariables = []
         needs_wrap = True
+        # Set when we encounter an array-typed `var` arg during the walk.
+        # Used downstream by the array-expansion phase.
+        array_var = None
 
+        # === Walk children, collecting arrays / values / op ============
         new_obj = copy.deepcopy(obj)
         for key, val in obj.items():
             if isinstance(val, dict) and "array" not in val:
-                # This is not an array object, then it's a nested ZCL expression
-                # so we need to proceed for nested processing.
+                # Nested ZCL expression -- recurse.
                 new_obj[key] = _process(val, variables)
             elif isinstance(val, (list, tuple)):
                 subitems = []
@@ -654,21 +740,18 @@ def process_expr(obj, ds):
                         elif 'var' in subitem:
                             var = variables.get(subitem['var'])
                             if var['type'] in ARRAY_TYPES and 'axes' not in subitem:
-                                # Add info about the fact that the "var" referenced
-                                # variable is an array, so that the validation can
-                                # work properly in the remaindere of the code.
+                                # Record the array variable so later phases
+                                # (swap, expansion) can do their job.
+                                array_var = var
                                 arrays.append(var['subvariables'])
                     subitems.append(subitem)
 
                 has_value = any(
                     'value' in item for item in subitems if not is_number(item)
                 )
-
                 if not has_value:
-                    # Since values can be see with `value` or `column` keys
-                    # check if `column` is there if not `value`
+                    # Values may be carried as either `value` or `column`.
                     has_value = any('column' in item for item in subitems if not is_number(item))
-
                 has_variable = any(
                     'var' in item for item in subitems if not is_number(item)
                 )
@@ -678,6 +761,9 @@ def process_expr(obj, ds):
 
                 new_obj[key] = subitems
             elif key == 'var':
+                # === Subvariable rewrite ===============================
+                # `{'var': sub_alias}` -> `{'var': parent_alias, 'axes': [sub_alias]}`.
+                # Also doubles as alias-existence validation.
                 var = variables.get(val)
                 if not var:
                     raise ValueError("Invalid variable alias '%s'" % val)
@@ -688,80 +774,21 @@ def process_expr(obj, ds):
                     new_obj['axes'] = [val]
             elif key == 'function':
                 op = val
-        
+
         obj = new_obj
 
-        if subvariables:
-            obj['subvariables'] = subvariables
-
-        # support for categorical variables with `any`
+        # === Type-aware `any` <-> `in` swap ============================
+        # The API expects `in` for categorical `.any()` and `any` for
+        # array `.in()`. Pick based on whether we saw an array arg.
         if not arrays and op == "any":
             obj["function"] = "in"
-
         if arrays and op == "in":
             op = "any"
             obj["function"] = "any"
 
+        # === Array variable expansion ==================================
         if arrays and op in ('any', 'all', 'is_valid', 'is_missing') and needs_wrap:
-            # Support for array variables.
-
-            if len(arrays) != 1:
-                raise ValueError
-
-            real_op = 'in'
-            expansion_op = 'or'
-            if op == 'all':
-                real_op = '=='
-                expansion_op = 'and'
-            elif op == 'is_valid':
-                real_op = 'all_valid'
-            elif op == 'is_missing':
-                real_op = 'is_missing'
-
-            if op in ('is_valid', 'is_missing'):
-                if len(values) != 0:
-                    raise ValueError
-
-                # Just swap the op. Yep, that's it.
-                obj['function'] = real_op
-            else:
-                if len(values) != 1:
-                    raise ValueError
-
-                subvariables = arrays[0]
-                value = values[0]
-
-                if op == 'all':
-                    inner_value = value.get("value", value.get("column", []))
-                    if len(inner_value) != 1:
-                        raise ValueError
-                    value.pop("column", None)
-                    value['value'] = inner_value[0]
-
-                if len(subvariables) == 1:
-                    obj['function'] = real_op
-                    obj['args'] = [
-                        {
-                            'var': var['alias'],
-                            'axes': [var['subreferences'][subvariables[0]]['alias']]
-                        },
-                        value
-                    ]
-                else:
-                    obj = {
-                        'function': expansion_op,
-                        'args': []
-                    }
-                    args_ref = obj['args']
-                    args_ref.extend(
-                        [{
-                            'function': real_op,
-                            'args': [
-                                {'var': var['alias'], 'axes': [var['subreferences'][subvar]['alias']]},
-                                value
-                            ]
-                        } for subvar in subvariables]
-                    )
+            obj = _expand_array_filter(obj, op, array_var, arrays, values)
 
         return obj
 
@@ -769,8 +796,7 @@ def process_expr(obj, ds):
         return [
             _process(copy.deepcopy(element), variables) for element in obj
         ]
-    else:
-        return _process(copy.deepcopy(obj), variables)
+    return _process(copy.deepcopy(obj), variables)
 
 
 def clean_integer(value):

--- a/scrunch/expressions.py
+++ b/scrunch/expressions.py
@@ -510,7 +510,7 @@ def adapt_multiple_response(var_alias, values, vars_by_alias):
     if all(isinstance(value, int) for value in values):
         # scenario var.any([1])
         column = values
-        variables = aliases.values()
+        subvars = list(aliases)
     else:
         # scenario var.any([subvar1, subvar2])
         # in this scenario, we only want category ids that refers to `selected` categories
@@ -697,6 +697,10 @@ def process_expr(obj, ds):
         # support for categorical variables with `any`
         if not arrays and op == "any":
             obj["function"] = "in"
+
+        if arrays and op == "in":
+            op = "any"
+            obj["function"] = "any"
 
         if arrays and op in ('any', 'all', 'is_valid', 'is_missing') and needs_wrap:
             # Support for array variables.

--- a/scrunch/expressions.py
+++ b/scrunch/expressions.py
@@ -791,6 +791,36 @@ def prettify(expr, ds=None):
     methods = {m[1]: m[0] for m in CRUNCH_METHOD_MAP.items()}
     functions = {f[1]: f[0] for f in CRUNCH_FUNC_MAP.items()}
 
+    def _resolve_variable(var):
+        is_url = validate_variable_url(var)
+
+        if not is_url:
+            return {"var": var}
+        elif not isinstance(ds, scrunch.datasets.BaseDataset):
+            raise Exception(
+                'Valid Dataset instance is required to resolve variable urls '
+                'in the expression'
+            )
+
+        # Transitional compatibility: old Crunch API responses may still return
+        # `variable` URL terms. Once all API responses use `var`/`axes`, this URL
+        # lookup path should be removed.
+        var_resource = ds.resource.session.get(var).payload
+        var_alias = var_resource.body["alias"]
+
+        # From an arbitrary URL we can detect whether this is a variable or a
+        # subvariable by checking the adjacent resources linked. A subvariable
+        # will point to its parent `/subvariables/` catalog and refer to its
+        # array variable by `.fragments["variable"]`.
+        is_subvariable = 'parent' in var_resource.catalogs and 'variable' in var_resource.fragments
+
+        if is_subvariable:
+            array_url = var_resource.fragments['variable']
+            array_var = ds.resource.session.get(array_url).payload
+            return {"var": array_var.body["alias"], "axes": [var_alias]}
+
+        return {"var": var_alias}
+
     def _resolve_variables(_expr):
         new_expr = dict(
             function=_expr['function'],
@@ -800,6 +830,8 @@ def prettify(expr, ds=None):
             if 'function' in arg:
                 # arg is a function, resolve inner variables
                 new_expr['args'].append(_resolve_variables(arg))
+            elif 'variable' in arg:
+                new_expr['args'].append(_resolve_variable(arg['variable']))
             else:
                 # arg is neither a variable or function, pass as is
                 new_expr['args'].append(arg)

--- a/scrunch/tests/test_cubes.py
+++ b/scrunch/tests/test_cubes.py
@@ -48,7 +48,7 @@ class TestCubes(TestDatasetBase, TestCase):
             "function": ">",
             "args": [
                 {
-                    "variable": "https://test.crunch.io/api/datasets/123456/variables/0001/"
+                    "var": "var1_alias"
                 },
                 {"value": 1},
             ],

--- a/scrunch/tests/test_datasets.py
+++ b/scrunch/tests/test_datasets.py
@@ -596,7 +596,6 @@ class TestExclusionFilters(TestDatasetBase, TestCase):
         """
         ds_res = self._dataset_mock()
         ds = StreamingDataset(ds_res)
-        var = ds['var1_alias']
 
         # Action!
         exclusion_filter = 'var1_alias != 0'
@@ -641,7 +640,6 @@ class TestExclusionFilters(TestDatasetBase, TestCase):
     def test_gt(self):
         ds_mock = self._dataset_mock()
         ds = StreamingDataset(ds_mock)
-        var = ds['var1_alias']
 
         data = self._exclude_payload(ds, 'var1_alias > 5')
         expected_expr_obj = {
@@ -658,7 +656,6 @@ class TestExclusionFilters(TestDatasetBase, TestCase):
     def test_in(self):
         ds_mock = self._dataset_mock()
         ds = StreamingDataset(ds_mock)
-        var = ds['var1_alias']
 
         data = self._exclude_payload(ds, 'var1_alias in [32766]')
         expected_expr_obj = {
@@ -676,7 +673,6 @@ class TestExclusionFilters(TestDatasetBase, TestCase):
     def test_in_multiple(self):
         ds_mock = self._dataset_mock()
         ds = StreamingDataset(ds_mock)
-        var = ds['var1_alias']
 
         data = self._exclude_payload(ds, 'var1_alias in (32766, 32767)')
         expected_expr_obj = {
@@ -709,8 +705,6 @@ class TestExclusionFilters(TestDatasetBase, TestCase):
 
         ds_mock = self._dataset_mock(variables=variables)
         ds = StreamingDataset(ds_mock)
-        var1 = ds['disposition']
-        var2 = ds['exit_status']
 
         data = self._exclude_payload(ds, 'not (disposition in (1, 2) and exit_status == 0)')
         expected_expr_obj = {
@@ -756,7 +750,6 @@ class TestExclusionFilters(TestDatasetBase, TestCase):
     def test_any(self):
         ds_mock = self._dataset_mock()
         ds = StreamingDataset(ds_mock)
-        var = ds['var1_alias']
 
         data = self._exclude_payload(ds, 'var1_alias.any([32766])')
         expected_expr_obj = {
@@ -780,7 +773,6 @@ class TestExclusionFilters(TestDatasetBase, TestCase):
     def test_not_any(self):
         ds_mock = self._dataset_mock()
         ds = StreamingDataset(ds_mock)
-        var = ds['var1_alias']
 
         data = self._exclude_payload(ds, 'not var1_alias.any([32766])')
         expected_expr_obj = {
@@ -809,7 +801,6 @@ class TestExclusionFilters(TestDatasetBase, TestCase):
     def test_any_multiple(self):
         ds_mock = self._dataset_mock()
         ds = StreamingDataset(ds_mock)
-        var = ds['var1_alias']
 
         data = self._exclude_payload(ds, 'var1_alias.any([32766, 32767])')
         expected_expr_obj = {
@@ -834,7 +825,6 @@ class TestExclusionFilters(TestDatasetBase, TestCase):
     def test_all(self):
         ds_mock = self._dataset_mock()
         ds = StreamingDataset(ds_mock)
-        var = ds['var1_alias']
 
         data = self._exclude_payload(ds, 'var1_alias.all([32767])')
         expected_expr_obj = {
@@ -856,7 +846,6 @@ class TestExclusionFilters(TestDatasetBase, TestCase):
     def test_not_all(self):
         ds_mock = self._dataset_mock()
         ds = StreamingDataset(ds_mock)
-        var = ds['var1_alias']
 
         data = self._exclude_payload(ds, 'not var1_alias.all([32767])')
         expected_expr_obj = {
@@ -885,7 +874,6 @@ class TestExclusionFilters(TestDatasetBase, TestCase):
     def test_all_or_all(self):
         ds_mock = self._dataset_mock()
         ds = StreamingDataset(ds_mock)
-        var = ds['var1_alias']
 
         data = self._exclude_payload(ds, 'var1_alias.all([1]) or var1_alias.all([2])')
         expected_expr_obj = {
@@ -927,7 +915,6 @@ class TestExclusionFilters(TestDatasetBase, TestCase):
     def test_not_all_or_all(self):
         ds_mock = self._dataset_mock()
         ds = StreamingDataset(ds_mock)
-        var = ds['var1_alias']
 
         data = self._exclude_payload(ds, 'not(var1_alias.all([1]) or var1_alias.all([2]))')
         expected_expr_obj = {
@@ -974,7 +961,6 @@ class TestExclusionFilters(TestDatasetBase, TestCase):
     def test_duplicates(self):
         ds_mock = self._dataset_mock()
         ds = StreamingDataset(ds_mock)
-        var = ds['var1_alias']
 
         data = self._exclude_payload(ds, 'var1_alias.duplicates()')
         expected_expr_obj = {
@@ -993,7 +979,6 @@ class TestExclusionFilters(TestDatasetBase, TestCase):
     def test_valid(self):
         ds_mock = self._dataset_mock()
         ds = StreamingDataset(ds_mock)
-        var = ds['var1_alias']
 
         data = self._exclude_payload(ds, 'valid(var1_alias)')
         expected_expr_obj = {
@@ -1012,7 +997,6 @@ class TestExclusionFilters(TestDatasetBase, TestCase):
     def test_not_valid(self):
         ds_mock = self._dataset_mock()
         ds = StreamingDataset(ds_mock)
-        var = ds['var1_alias']
 
         data = self._exclude_payload(ds, 'not valid(var1_alias)')
         expected_expr_obj = {
@@ -1036,7 +1020,6 @@ class TestExclusionFilters(TestDatasetBase, TestCase):
     def test_missing(self):
         ds_mock = self._dataset_mock()
         ds = StreamingDataset(ds_mock)
-        var = ds['var1_alias']
 
         data = self._exclude_payload(ds, 'missing(var1_alias)')
         expected_expr_obj = {
@@ -1055,7 +1038,6 @@ class TestExclusionFilters(TestDatasetBase, TestCase):
     def test_not_missing(self):
         ds_mock = self._dataset_mock()
         ds = StreamingDataset(ds_mock)
-        var = ds['var1_alias']
 
         data = self._exclude_payload(ds, 'not missing(var1_alias)')
         expected_expr_obj = {
@@ -1079,7 +1061,6 @@ class TestExclusionFilters(TestDatasetBase, TestCase):
     def test_equal(self):
         ds_mock = self._dataset_mock()
         ds = StreamingDataset(ds_mock)
-        var = ds['var1_alias']
 
         data = self._exclude_payload(ds, 'var1_alias == 1')
         expected_expr_obj = {
@@ -1115,8 +1096,6 @@ class TestExclusionFilters(TestDatasetBase, TestCase):
         }
         ds_mock = self._dataset_mock(variables=variables)
         ds = StreamingDataset(ds_mock)
-        var1 = ds['disposition']
-        var2 = ds['exit_status']
 
         data = self._exclude_payload(ds, '(disposition != 1 and (not valid(exit_status) or exit_status >= 1)) or (disposition == 0 and exit_status == 0) or (disposition == 0 and exit_status == 1)')
         expected_expr_obj = {

--- a/scrunch/tests/test_datasets.py
+++ b/scrunch/tests/test_datasets.py
@@ -363,7 +363,7 @@ class TestDatasets(TestDatasetBase, TestCase):
                             {
                                 'function': '*',
                                 'args': [
-                                    {'variable': 'weekly_rent'},
+                                    {'var': 'weekly_rent'},
                                     {'value': 52}
                                 ]
                             },
@@ -560,11 +560,6 @@ class TestDatasets(TestDatasetBase, TestCase):
             if use_fsum and res == 1.0:
                 raise Exception('1.0')
 
-        # `sum` fails
-        with pytest.raises(Exception, match='not 1.0'):
-            _test_sum(targets[0]['foo'])
-
-        # `fsum` does not
         with pytest.raises(Exception, match='1.0'):
             _test_sum(targets[0]['foo'], use_fsum=True)
 
@@ -602,7 +597,7 @@ class TestExclusionFilters(TestDatasetBase, TestCase):
             'expression': {
                 'function': '!=',
                 'args': [
-                    {'variable': var.url},  # Crunch needs variable URLs!
+                    {'var': 'var1_alias'},
                     {'value': 0}
                 ]
             }
@@ -638,7 +633,7 @@ class TestExclusionFilters(TestDatasetBase, TestCase):
             'expression': {
                 'function': '>',
                 'args': [
-                    {'variable': var.url},
+                    {'var': 'var1_alias'},
                     {'value': 5}
                 ]
             }
@@ -655,7 +650,7 @@ class TestExclusionFilters(TestDatasetBase, TestCase):
             "expression": {
                 "function": "in",
                 "args": [
-                    {"variable": var.url},
+                    {"var": "var1_alias"},
                     {"value": [32766]}
                 ]
             }
@@ -673,7 +668,7 @@ class TestExclusionFilters(TestDatasetBase, TestCase):
             "expression": {
                 "function": "in",
                 "args": [
-                    {"variable": var.url},
+                    {"var": "var1_alias"},
                     {"value": [32766, 32767]}
                 ]
             }
@@ -714,7 +709,7 @@ class TestExclusionFilters(TestDatasetBase, TestCase):
                                 "function": "in",
                                 "args": [
                                     {
-                                        "variable": var1.url
+                                        "var": "disposition"
                                     },
                                     {
                                         "value": [
@@ -728,7 +723,7 @@ class TestExclusionFilters(TestDatasetBase, TestCase):
                                 "function": "==",
                                 "args": [
                                     {
-                                        "variable": var2.url
+                                        "var": "exit_status"
                                     },
                                     {
                                         "value": 0
@@ -754,7 +749,7 @@ class TestExclusionFilters(TestDatasetBase, TestCase):
                 "function": "in",
                 "args": [
                     {
-                        "variable": var.url
+                        "var": "var1_alias"
                     },
                     {
                         "value": [
@@ -781,7 +776,7 @@ class TestExclusionFilters(TestDatasetBase, TestCase):
                         "function": "in",
                         "args": [
                             {
-                                "variable": var.url
+                                "var": "var1_alias"
                             },
                             {
                                 "value": [
@@ -807,7 +802,7 @@ class TestExclusionFilters(TestDatasetBase, TestCase):
                 "function": "in",
                 "args": [
                     {
-                        "variable": var.url
+                        "var": "var1_alias"
                     },
                     {
                         "value": [
@@ -831,7 +826,7 @@ class TestExclusionFilters(TestDatasetBase, TestCase):
             "expression": {
                 "args": [
                     {
-                        "variable": var.url
+                        "var": "var1_alias"
                     },
                     {
                         "value": [32767]
@@ -857,7 +852,7 @@ class TestExclusionFilters(TestDatasetBase, TestCase):
                         "function": "all",
                         "args": [
                             {
-                                "variable": var.url
+                                "var": "var1_alias"
                             },
                             {
                                 "value": [
@@ -884,7 +879,7 @@ class TestExclusionFilters(TestDatasetBase, TestCase):
                     {
                         "args": [
                             {
-                                "variable": var.url
+                                "var": "var1_alias"
                             },
                             {
                                 "value": [
@@ -897,7 +892,7 @@ class TestExclusionFilters(TestDatasetBase, TestCase):
                     {
                         "args": [
                             {
-                                "variable": var.url
+                                "var": "var1_alias"
                             },
                             {
                                 "value": [
@@ -929,7 +924,7 @@ class TestExclusionFilters(TestDatasetBase, TestCase):
                             {
                                 "args": [
                                     {
-                                        "variable": var.url
+                                        "var": "var1_alias"
                                     },
                                     {
                                         "value": [
@@ -942,7 +937,7 @@ class TestExclusionFilters(TestDatasetBase, TestCase):
                             {
                                 "args": [
                                     {
-                                        "variable": var.url
+                                        "var": "var1_alias"
                                     },
                                     {
                                         "value": [
@@ -972,7 +967,7 @@ class TestExclusionFilters(TestDatasetBase, TestCase):
                 "function": "duplicates",
                 "args": [
                     {
-                        "variable": var.url
+                        "var": "var1_alias"
                     }
                 ]
             }
@@ -991,7 +986,7 @@ class TestExclusionFilters(TestDatasetBase, TestCase):
                 "function": "is_valid",
                 "args": [
                     {
-                        "variable": var.url
+                        "var": "var1_alias"
                     }
                 ]
             }
@@ -1011,7 +1006,7 @@ class TestExclusionFilters(TestDatasetBase, TestCase):
                     {
                         "args": [
                             {
-                                "variable": var.url
+                                "var": "var1_alias"
                             }
                         ],
                         "function": "is_valid"
@@ -1033,7 +1028,7 @@ class TestExclusionFilters(TestDatasetBase, TestCase):
             "expression": {
                 "args": [
                     {
-                        "variable": var.url
+                        "var": "var1_alias"
                     }
                 ],
                 "function": "is_missing"
@@ -1056,7 +1051,7 @@ class TestExclusionFilters(TestDatasetBase, TestCase):
                         "function": "is_missing",
                         "args": [
                             {
-                                "variable": var.url
+                                "var": "var1_alias"
                             }
                         ]
                     }
@@ -1076,7 +1071,7 @@ class TestExclusionFilters(TestDatasetBase, TestCase):
             "expression": {
                 "args": [
                     {
-                        "variable": var.url
+                        "var": "var1_alias"
                     },
                     {
                         "value": 1
@@ -1117,7 +1112,7 @@ class TestExclusionFilters(TestDatasetBase, TestCase):
                             {
                                 "args": [
                                     {
-                                        "variable": var1.url
+                                        "var": "disposition"
                                     },
                                     {
                                         "value": 1
@@ -1132,7 +1127,7 @@ class TestExclusionFilters(TestDatasetBase, TestCase):
                                             {
                                                 "args": [
                                                     {
-                                                        "variable": var2.url
+                                                        "var": "exit_status"
                                                     }
                                                 ],
                                                 "function": "is_valid"
@@ -1143,7 +1138,7 @@ class TestExclusionFilters(TestDatasetBase, TestCase):
                                     {
                                         "args": [
                                             {
-                                                "variable": var2.url
+                                                "var": "exit_status"
                                             },
                                             {
                                                 "value": 1
@@ -1164,7 +1159,7 @@ class TestExclusionFilters(TestDatasetBase, TestCase):
                                     {
                                         "args": [
                                             {
-                                                "variable": var1.url
+                                                "var": "disposition"
                                             },
                                             {
                                                 "value": 0
@@ -1175,7 +1170,7 @@ class TestExclusionFilters(TestDatasetBase, TestCase):
                                     {
                                         "args": [
                                             {
-                                                "variable": var2.url
+                                                "var": "exit_status"
                                             },
                                             {
                                                 "value": 0
@@ -1191,7 +1186,7 @@ class TestExclusionFilters(TestDatasetBase, TestCase):
                                     {
                                         "args": [
                                             {
-                                                "variable": var1.url
+                                                "var": "disposition"
                                             },
                                             {
                                                 "value": 0
@@ -1202,7 +1197,7 @@ class TestExclusionFilters(TestDatasetBase, TestCase):
                                     {
                                         "args": [
                                             {
-                                                "variable": var2.url
+                                                "var": "exit_status"
                                             },
                                             {
                                                 "value": 1
@@ -1230,7 +1225,7 @@ class TestExclusionFilters(TestDatasetBase, TestCase):
         expr = {
             "args": [
                 {
-                    "variable": "http://test.crunch.io/api/datasets/123/variables/0002/"
+                    "var": "var1_alias"
                 },
                 {
                     "value": 1
@@ -2115,8 +2110,8 @@ class TestFillVariables(TestCase):
     def test_recode_w_fill(self):
         ds, session = self.prepare_ds()
         responses = [
-            {"case": "var_a == 1", "variable": "var_a"},
-            {"case": "var_b == 1", "variable": "var_b"}
+            {"case": "var_a == 1", "var": "var_a"},
+            {"case": "var_b == 1", "var": "var_b"}
         ]
 
         # This is what we want to test for!
@@ -2142,14 +2137,14 @@ class TestFillVariables(TestCase):
                 {
                     "function": "==",
                     "args": [
-                        {"variable": "http://host/api/projects/abc/variables/001/"},
+                        {"var": "var_a"},
                         {"value": 1}
                     ]
                 },
                 {
                     "function": "==",
                     "args": [
-                        {"variable": "http://host/api/projects/abc/variables/002/"},
+                        {"var": "var_b"},
                         {"value": 1}
                     ]
                 }
@@ -2161,8 +2156,8 @@ class TestFillVariables(TestCase):
                 case_expr,
                 {
                     "map": {
-                        "1": {"variable": "001"},
-                        "2": {"variable": "002"}
+                        "1": {"var": "var_a"},
+                        "2": {"var": "var_b"}
                     }
                 }
             ],
@@ -2182,7 +2177,7 @@ class TestFillVariables(TestCase):
     def test_else_code(self):
         ds, session = self.prepare_ds()
         responses = [
-            {"case": "var_a == 1", "variable": "var_a"},
+            {"case": "var_a == 1", "var": "var_a"},
             {"case": "else", "missing": True, "name": "Not Asked", "id": 99}
         ]
 
@@ -2209,7 +2204,7 @@ class TestFillVariables(TestCase):
                 {
                     "function": "==",
                     "args": [
-                        {"variable": "http://host/api/projects/abc/variables/001/"},
+                        {"var": "var_a"},
                         {"value": 1}
                     ]
                 },
@@ -2221,7 +2216,7 @@ class TestFillVariables(TestCase):
                 case_expr,
                 {
                     "map": {
-                        "1": {"variable": "001"},
+                        "1": {"var": "var_a"},
                     }
                 }
             ],
@@ -2239,8 +2234,8 @@ class TestFillVariables(TestCase):
     def test_else_var(self):
         ds, session = self.prepare_ds()
         responses = [
-            {"case": "var_a == 1", "variable": "var_a"},
-            {"case": "else", "variable": "var_b"}
+            {"case": "var_a == 1", "var": "var_a"},
+            {"case": "else", "var": "var_b"}
         ]
 
         # This is what we want to test for!
@@ -2266,7 +2261,7 @@ class TestFillVariables(TestCase):
                 {
                     "function": "==",
                     "args": [
-                        {"variable": "http://host/api/projects/abc/variables/001/"},
+                        {"var": "var_a"},
                         {"value": 1}
                     ]
                 },
@@ -2278,8 +2273,8 @@ class TestFillVariables(TestCase):
                 case_expr,
                 {
                     "map": {
-                        "1": {"variable": "001"},
-                        "-1": {"variable": "002"}
+                        "1": {"var": "var_a"},
+                        "-1": {"var": "var_b"}
                     }
                 }
             ],
@@ -2372,7 +2367,7 @@ class TestRecode(TestDatasetBase):
                     }, {
                         'function': '>',
                         'args': [
-                            {'variable': 'https://test.crunch.io/api/datasets/123456/variables/001/'},
+                            {'var': 'var_a'},
                             {'value': 5}
                         ]
                     }, {
@@ -2380,12 +2375,12 @@ class TestRecode(TestDatasetBase):
                         'args': [{
                             'function': '<',
                             'args': [
-                                {'variable': 'https://test.crunch.io/api/datasets/123456/variables/002/'},
+                                {'var': 'var_b'},
                                 {'value': 10}
                             ]}, {
                             'function': 'in',
                             'args': [
-                                {'variable': 'https://test.crunch.io/api/datasets/123456/variables/003/'},
+                                {'var': 'var_c'},
                                 {'value': [1, 2, 3]}
                             ]
                         }]
@@ -2394,7 +2389,7 @@ class TestRecode(TestDatasetBase):
                         'args': [{
                             'function': '==',
                             'args': [
-                                {'variable': 'https://test.crunch.io/api/datasets/123456/variables/004/'},
+                                {'var': 'gender'},
                                 {'value': 1}
                             ]
                         }, {
@@ -2402,13 +2397,13 @@ class TestRecode(TestDatasetBase):
                             'args': [{
                                 'function': '>=',
                                 'args': [
-                                    {'variable': 'https://test.crunch.io/api/datasets/123456/variables/005/'},
+                                    {'var': 'age'},
                                     {'value': 16}
                                 ]
                             }, {
                                 'function': '<=',
                                 'args': [
-                                    {'variable': 'https://test.crunch.io/api/datasets/123456/variables/005/'},
+                                    {'var': 'age'},
                                     {'value': 24}
                                 ]
                             }]
@@ -2501,7 +2496,7 @@ class TestRecode(TestDatasetBase):
                                         # 'var_a > 5'
                                         'function': '>',
                                         'args': [
-                                            {'variable': 'https://test.crunch.io/api/datasets/123456/variables/%s/' % variables['var_a']['id']},
+                                            {'var': 'var_a'},
                                             {'value': 5}
                                         ]
                                     }]
@@ -2529,13 +2524,13 @@ class TestRecode(TestDatasetBase):
                                         'args': [{
                                             'function': '<',
                                             'args': [
-                                                {'variable': 'https://test.crunch.io/api/datasets/123456/variables/%s/' % variables['var_b']['id']},
+                                                {'var': 'var_b'},
                                                 {'value': 10}
                                             ]
                                         }, {
                                             'function': 'in',
                                             'args': [
-                                                {'variable': 'https://test.crunch.io/api/datasets/123456/variables/%s/' % variables['var_c']['id']},
+                                                {'var': 'var_c'},
                                                 {'value': [1, 2, 3]}
                                             ]
                                         }]
@@ -2563,15 +2558,15 @@ class TestRecode(TestDatasetBase):
                                         'function': 'and',
                                         'args': [{
                                             'function': '==',
-                                            'args': [{'variable': 'https://test.crunch.io/api/datasets/123456/variables/%s/' % variables['gender']['id']}, {'value': 1}]
+                                            'args': [{'var': 'gender'}, {'value': 1}]
                                         }, {
                                             'function': 'and',
                                             'args': [{
                                                 'function': '>=',
-                                                'args': [{'variable': 'https://test.crunch.io/api/datasets/123456/variables/%s/' % variables['age']['id']}, {'value': 16}]
+                                                'args': [{'var': 'age'}, {'value': 16}]
                                             }, {
                                                 'function': '<=',
-                                                'args': [{'variable': 'https://test.crunch.io/api/datasets/123456/variables/%s/' % variables['age']['id']}, {'value': 24}]
+                                                'args': [{'var': 'age'}, {'value': 24}]
                                             }]
                                         }]
                                     }]
@@ -2688,7 +2683,7 @@ class TestRecode(TestDatasetBase):
                             "function": "==",
                             "args": [
                                 {
-                                    "variable": "https://test.crunch.io/api/datasets/123456/variables/var_a/"
+                                    "var": "var_a"
                                 },
                                 {
                                     "value": 1
@@ -2699,7 +2694,7 @@ class TestRecode(TestDatasetBase):
                             "function": "==",
                             "args": [
                                 {
-                                    "variable": "https://test.crunch.io/api/datasets/123456/variables/var_b/"
+                                    "var": "var_b"
                                 },
                                 {
                                     "value": 1
@@ -2716,7 +2711,7 @@ class TestRecode(TestDatasetBase):
                                             "function": "==",
                                             "args": [
                                                 {
-                                                    "variable": "https://test.crunch.io/api/datasets/123456/variables/var_a/"
+                                                    "var": "var_a"
                                                 },
                                                 {
                                                     "value": 1
@@ -2732,7 +2727,7 @@ class TestRecode(TestDatasetBase):
                                             "function": "==",
                                             "args": [
                                                 {
-                                                    "variable": "https://test.crunch.io/api/datasets/123456/variables/var_b/"
+                                                    "var": "var_b"
                                                 },
                                                 {
                                                     "value": 1
@@ -2825,7 +2820,7 @@ class TestRecode(TestDatasetBase):
                                                     "function": "==",
                                                     "args": [
                                                         {
-                                                            "variable": "https://test.crunch.io/api/datasets/123456/variables/age/"
+                                                            "var": "age"
                                                         },
                                                         {
                                                             "value": 20
@@ -2846,7 +2841,7 @@ class TestRecode(TestDatasetBase):
                                                     "function": "==",
                                                     "args": [
                                                         {
-                                                            "variable": "https://test.crunch.io/api/datasets/123456/variables/age/"
+                                                            "var": "age"
                                                         },
                                                         {
                                                             "value": 50
@@ -2873,7 +2868,7 @@ class TestRecode(TestDatasetBase):
                                                                     "function": "==",
                                                                     "args": [
                                                                         {
-                                                                            "variable": "https://test.crunch.io/api/datasets/123456/variables/age/"
+                                                                            "var": "age"
                                                                         },
                                                                         {
                                                                             "value": 20
@@ -2889,7 +2884,7 @@ class TestRecode(TestDatasetBase):
                                                                     "function": "==",
                                                                     "args": [
                                                                         {
-                                                                            "variable": "https://test.crunch.io/api/datasets/123456/variables/age/"
+                                                                            "var": "age"
                                                                         },
                                                                         {
                                                                             "value": 50
@@ -3015,7 +3010,7 @@ class TestRecode(TestDatasetBase):
                                                             "function": "==",
                                                             "args": [
                                                                 {
-                                                                    "variable": "https://test.crunch.io/api/datasets/123456/variables/age/"
+                                                                    "var": "age"
                                                                 },
                                                                 {
                                                                     "value": 21
@@ -3029,7 +3024,7 @@ class TestRecode(TestDatasetBase):
                                                                     "function": "is_missing",
                                                                     "args": [
                                                                         {
-                                                                            "variable": "https://test.crunch.io/api/datasets/123456/variables/age/"
+                                                                            "var": "age"
                                                                         }
                                                                     ]
                                                                 }
@@ -3047,7 +3042,7 @@ class TestRecode(TestDatasetBase):
                                                                     "function": "==",
                                                                     "args": [
                                                                         {
-                                                                            "variable": "https://test.crunch.io/api/datasets/123456/variables/age/"
+                                                                            "var": "age"
                                                                         },
                                                                         {
                                                                             "value": 21
@@ -3063,7 +3058,7 @@ class TestRecode(TestDatasetBase):
                                                                     "function": "is_missing",
                                                                     "args": [
                                                                         {
-                                                                            "variable": "https://test.crunch.io/api/datasets/123456/variables/age/"
+                                                                            "var": "age"
                                                                         }
                                                                     ]
                                                                 }
@@ -3075,7 +3070,7 @@ class TestRecode(TestDatasetBase):
                                                     "function": "is_missing",
                                                     "args": [
                                                         {
-                                                            "variable": "https://test.crunch.io/api/datasets/123456/variables/age/"
+                                                            "var": "age"
                                                         }
                                                     ]
                                                 }
@@ -3096,7 +3091,7 @@ class TestRecode(TestDatasetBase):
                                                             "function": "==",
                                                             "args": [
                                                                 {
-                                                                    "variable": "https://test.crunch.io/api/datasets/123456/variables/age/"
+                                                                    "var": "age"
                                                                 },
                                                                 {
                                                                     "value": 51
@@ -3110,7 +3105,7 @@ class TestRecode(TestDatasetBase):
                                                                     "function": "is_missing",
                                                                     "args": [
                                                                         {
-                                                                            "variable": "https://test.crunch.io/api/datasets/123456/variables/age/"
+                                                                            "var": "age"
                                                                         }
                                                                     ]
                                                                 }
@@ -3128,7 +3123,7 @@ class TestRecode(TestDatasetBase):
                                                                     "function": "==",
                                                                     "args": [
                                                                         {
-                                                                            "variable": "https://test.crunch.io/api/datasets/123456/variables/age/"
+                                                                            "var": "age"
                                                                         },
                                                                         {
                                                                             "value": 51
@@ -3144,7 +3139,7 @@ class TestRecode(TestDatasetBase):
                                                                     "function": "is_missing",
                                                                     "args": [
                                                                         {
-                                                                            "variable": "https://test.crunch.io/api/datasets/123456/variables/age/"
+                                                                            "var": "age"
                                                                         }
                                                                     ]
                                                                 }
@@ -3156,7 +3151,7 @@ class TestRecode(TestDatasetBase):
                                                     "function": "is_missing",
                                                     "args": [
                                                         {
-                                                            "variable": "https://test.crunch.io/api/datasets/123456/variables/age/"
+                                                            "var": "age"
                                                         }
                                                     ]
                                                 }
@@ -3183,7 +3178,7 @@ class TestRecode(TestDatasetBase):
                                                                             "function": "==",
                                                                             "args": [
                                                                                 {
-                                                                                    "variable": "https://test.crunch.io/api/datasets/123456/variables/age/"
+                                                                                    "var": "age"
                                                                                 },
                                                                                 {
                                                                                     "value": 21
@@ -3199,7 +3194,7 @@ class TestRecode(TestDatasetBase):
                                                                             "function": "==",
                                                                             "args": [
                                                                                 {
-                                                                                    "variable": "https://test.crunch.io/api/datasets/123456/variables/age/"
+                                                                                    "var": "age"
                                                                                 },
                                                                                 {
                                                                                     "value": 51
@@ -3217,7 +3212,7 @@ class TestRecode(TestDatasetBase):
                                                                     "function": ">",
                                                                     "args": [
                                                                         {
-                                                                            "variable": "https://test.crunch.io/api/datasets/123456/variables/age/"
+                                                                            "var": "age"
                                                                         },
                                                                         {
                                                                             "value": 100
@@ -3238,7 +3233,7 @@ class TestRecode(TestDatasetBase):
                                                                     "function": "==",
                                                                     "args": [
                                                                         {
-                                                                            "variable": "https://test.crunch.io/api/datasets/123456/variables/age/"
+                                                                            "var": "age"
                                                                         },
                                                                         {
                                                                             "value": 21
@@ -3249,7 +3244,7 @@ class TestRecode(TestDatasetBase):
                                                                     "function": "==",
                                                                     "args": [
                                                                         {
-                                                                            "variable": "https://test.crunch.io/api/datasets/123456/variables/age/"
+                                                                            "var": "age"
                                                                         },
                                                                         {
                                                                             "value": 51
@@ -3265,7 +3260,7 @@ class TestRecode(TestDatasetBase):
                                                                     "function": ">",
                                                                     "args": [
                                                                         {
-                                                                            "variable": "https://test.crunch.io/api/datasets/123456/variables/age/"
+                                                                            "var": "age"
                                                                         },
                                                                         {
                                                                             "value": 100
@@ -3280,7 +3275,7 @@ class TestRecode(TestDatasetBase):
                                                     "function": ">",
                                                     "args": [
                                                         {
-                                                            "variable": "https://test.crunch.io/api/datasets/123456/variables/age/"
+                                                            "var": "age"
                                                         },
                                                         {
                                                             "value": 100
@@ -3396,7 +3391,7 @@ class TestRecode(TestDatasetBase):
                                                             "function": ">",
                                                             "args": [
                                                                 {
-                                                                    "variable": "https://test.crunch.io/api/datasets/123456/variables/age/"
+                                                                    "var": "age"
                                                                 },
                                                                 {
                                                                     "value": 40
@@ -3410,7 +3405,7 @@ class TestRecode(TestDatasetBase):
                                                                     "function": "is_missing",
                                                                     "args": [
                                                                         {
-                                                                            "variable": "https://test.crunch.io/api/datasets/123456/variables/age/"
+                                                                            "var": "age"
                                                                         }
                                                                     ]
                                                                 }
@@ -3428,7 +3423,7 @@ class TestRecode(TestDatasetBase):
                                                                     "function": ">",
                                                                     "args": [
                                                                         {
-                                                                            "variable": "https://test.crunch.io/api/datasets/123456/variables/age/"
+                                                                            "var": "age"
                                                                         },
                                                                         {
                                                                             "value": 40
@@ -3444,7 +3439,7 @@ class TestRecode(TestDatasetBase):
                                                                     "function": "is_missing",
                                                                     "args": [
                                                                         {
-                                                                            "variable": "https://test.crunch.io/api/datasets/123456/variables/age/"
+                                                                            "var": "age"
                                                                         }
                                                                     ]
                                                                 }
@@ -3456,7 +3451,7 @@ class TestRecode(TestDatasetBase):
                                                     "function": "is_missing",
                                                     "args": [
                                                         {
-                                                            "variable": "https://test.crunch.io/api/datasets/123456/variables/age/"
+                                                            "var": "age"
                                                         }
                                                     ]
                                                 }
@@ -3477,7 +3472,7 @@ class TestRecode(TestDatasetBase):
                                                             "function": "<=",
                                                             "args": [
                                                                 {
-                                                                    "variable": "https://test.crunch.io/api/datasets/123456/variables/age/"
+                                                                    "var": "age"
                                                                 },
                                                                 {
                                                                     "value": 40
@@ -3491,7 +3486,7 @@ class TestRecode(TestDatasetBase):
                                                                     "function": "is_missing",
                                                                     "args": [
                                                                         {
-                                                                            "variable": "https://test.crunch.io/api/datasets/123456/variables/age/"
+                                                                            "var": "age"
                                                                         }
                                                                     ]
                                                                 }
@@ -3509,7 +3504,7 @@ class TestRecode(TestDatasetBase):
                                                                     "function": "<=",
                                                                     "args": [
                                                                         {
-                                                                            "variable": "https://test.crunch.io/api/datasets/123456/variables/age/"
+                                                                            "var": "age"
                                                                         },
                                                                         {
                                                                             "value": 40
@@ -3525,7 +3520,7 @@ class TestRecode(TestDatasetBase):
                                                                     "function": "is_missing",
                                                                     "args": [
                                                                         {
-                                                                            "variable": "https://test.crunch.io/api/datasets/123456/variables/age/"
+                                                                            "var": "age"
                                                                         }
                                                                     ]
                                                                 }
@@ -3537,7 +3532,7 @@ class TestRecode(TestDatasetBase):
                                                     "function": "is_missing",
                                                     "args": [
                                                         {
-                                                            "variable": "https://test.crunch.io/api/datasets/123456/variables/age/"
+                                                            "var": "age"
                                                         }
                                                     ]
                                                 }
@@ -3634,14 +3629,14 @@ class TestRecode(TestDatasetBase):
                                         {
                                             'function': '==',
                                             'args': [
-                                                {'variable': 'https://test.crunch.io/api/datasets/123456/variables/%s/' % variables['var_a']['id']},
+                                                {'var': 'var_a'},
                                                 {'value': 1}
                                             ]
                                         },
                                         {
                                             'function': '==',
                                             'args': [
-                                                {'variable': 'https://test.crunch.io/api/datasets/123456/variables/%s/' % variables['var_a']['id']},
+                                                {'var': 'var_a'},
                                                 {'value': 2}
                                             ]
                                         }
@@ -3658,14 +3653,14 @@ class TestRecode(TestDatasetBase):
                                         {
                                             'function': '==',
                                             'args': [
-                                                {'variable': 'https://test.crunch.io/api/datasets/123456/variables/%s/' % variables['var_b']['id']},
+                                                {'var': 'var_b'},
                                                 {'value': 1}
                                             ]
                                         },
                                         {
                                             'function': '==',
                                             'args': [
-                                                {'variable': 'https://test.crunch.io/api/datasets/123456/variables/%s/' % variables['var_b']['id']},
+                                                {'var': 'var_b'},
                                                 {'value': 2}
                                             ]
                                         }
@@ -3682,14 +3677,14 @@ class TestRecode(TestDatasetBase):
                                         {
                                             'function': '==',
                                             'args': [
-                                                {'variable': 'https://test.crunch.io/api/datasets/123456/variables/%s/' % variables['var_c']['id']},
+                                                {'var': 'var_c'},
                                                 {'value': 1}
                                             ]
                                         },
                                         {
                                             'function': '==',
                                             'args': [
-                                                {'variable': 'https://test.crunch.io/api/datasets/123456/variables/%s/' % variables['var_c']['id']},
+                                                {'var': 'var_c'},
                                                 {'value': 2}
                                             ]
                                         }
@@ -5953,7 +5948,7 @@ class TestFilter(TestDatasetBase, TestCase):
                 'expression': {
                     'function': '!=',
                     'args': [
-                        {'variable': var.url},
+                        {'var': var.alias},
                         {'value': 0}
                     ]
                 }
@@ -6061,7 +6056,7 @@ class TestMultitable(TestDatasetBase, TestCase):
                 'template': [
                     {
                         'query': [
-                            {'variable': 'https://test.crunch.io/api/datasets/123456/variables/0001/'}
+                            {'var': 'var1_alias'}
                         ]
                     }
                 ]
@@ -6268,7 +6263,7 @@ class TestMutableMixin(TestDatasetBase):
                    "function": ">",
                    "args": [
                         {
-                            'variable': 'https://test.crunch.io/api/datasets/123456/variables/var_d/'
+                            'var': 'endtime'
                         },
                         {
                             "value": "2024-06-03T22:53:52.393"

--- a/scrunch/tests/test_datasets.py
+++ b/scrunch/tests/test_datasets.py
@@ -401,7 +401,7 @@ class TestDatasets(TestDatasetBase, TestCase):
                     'expr': {
                         'function': 'rollup',
                         'args': [
-                            {'variable': 'https://test.crunch.io/api/datasets/123456/variables/001/'},
+                            {'var': 'datetime_var'},
                             {'value': 'Y'}
                         ]
                     },
@@ -570,6 +570,21 @@ class TestDatasets(TestDatasetBase, TestCase):
         # mock the variable creation
         ds._var_create_reload_return = MagicMock()
         ds.derive_weight(targets=targets, alias='weight', name='Weight')
+        ds._var_create_reload_return.assert_called_with({
+            'element': 'shoji:entity',
+            'body': {
+                'name': 'Weight',
+                'alias': 'weight',
+                'description': '',
+                'derivation': {
+                    'function': 'rake',
+                    'args': [{
+                        'var': 'foo',
+                        'targets': list(map(list, targets[0]['foo'].items()))
+                    }]
+                }
+            }
+        })
 
 
 class TestExclusionFilters(TestDatasetBase, TestCase):
@@ -2110,8 +2125,8 @@ class TestFillVariables(TestCase):
     def test_recode_w_fill(self):
         ds, session = self.prepare_ds()
         responses = [
-            {"case": "var_a == 1", "var": "var_a"},
-            {"case": "var_b == 1", "var": "var_b"}
+            {"case": "var_a == 1", "variable": "var_a"},
+            {"case": "var_b == 1", "variable": "var_b"}
         ]
 
         # This is what we want to test for!
@@ -2177,7 +2192,7 @@ class TestFillVariables(TestCase):
     def test_else_code(self):
         ds, session = self.prepare_ds()
         responses = [
-            {"case": "var_a == 1", "var": "var_a"},
+            {"case": "var_a == 1", "variable": "var_a"},
             {"case": "else", "missing": True, "name": "Not Asked", "id": 99}
         ]
 
@@ -2234,8 +2249,8 @@ class TestFillVariables(TestCase):
     def test_else_var(self):
         ds, session = self.prepare_ds()
         responses = [
-            {"case": "var_a == 1", "var": "var_a"},
-            {"case": "else", "var": "var_b"}
+            {"case": "var_a == 1", "variable": "var_a"},
+            {"case": "else", "variable": "var_b"}
         ]
 
         # This is what we want to test for!
@@ -3705,11 +3720,13 @@ class TestCopyVariable(TestCase):
     def test_base_variable(self):
         ds_res = mock.MagicMock()
         var_res = mock.MagicMock()
-        var_res.entity.body = {'type': 'numeric'}
+        var_res.entity.body = {'type': 'numeric', 'alias': 'original'}
 
         def getitem(key):
             if key == 'derived':
                 return False
+            if key == 'alias':
+                return 'original'
         var_res.__getitem__.side_effect = getitem
         var_res.entity.self = '/variable/url/'
         ds = StreamingDataset(ds_res)
@@ -3722,7 +3739,7 @@ class TestCopyVariable(TestCase):
                 'name': 'copy',
                 'derivation': {
                     'function': 'copy_variable',
-                    'args': [{'variable': '/variable/url/'}]
+                    'args': [{'var': 'original'}]
                 }
             }
         })
@@ -6474,9 +6491,9 @@ class TestSubvariableCodes:
         dataset.bind_categorical_array("My Array", "my_array", subvariables)
 
         array_map = {
-            '1': {'variable': '/variables/var_1/'},
-            '2': {'variable': '/variables/var_2/'},
-            '3': {'variable': '/variables/var_3/'}
+            '1': {'var': 'var_1'},
+            '2': {'var': 'var_2'},
+            '3': {'var': 'var_3'}
         }
         subreferences = [
             # See how var_1 and var_2 have been disambiguated because
@@ -6512,9 +6529,9 @@ class TestSubvariableCodes:
         dataset.bind_categorical_array("My Array", "my_array", subvariables, subvariable_codes=subvariable_codes)
 
         array_map = {
-            '1': {'variable': '/variables/var_1/'},
-            '2': {'variable': '/variables/var_2/'},
-            '3': {'variable': '/variables/var_3/'}
+            '1': {'var': 'var_1'},
+            '2': {'var': 'var_2'},
+            '3': {'var': 'var_3'}
         }
         subreferences = [
             {'alias': 'code_1', 'name': 'Variable 1'},
@@ -6563,6 +6580,7 @@ class TestSubvariableCodes:
             "self": var_url,
             "body": {
                 "derived": False,
+                "alias": "source_var",
                 "subvariables": [
                     "%s001/" % var_url,
                     "%s002/" % var_url,
@@ -6586,7 +6604,7 @@ class TestSubvariableCodes:
         ]
         expression = {
             "function": "copy_variable",
-            "args": [{"variable": var_url}],
+            "args": [{"var": "source_var"}],
             "references": {"subreferences": subreferences}
         }
         assert args == [{
@@ -6624,6 +6642,7 @@ class TestSubvariableCodes:
             "self": var_url,
             "body": {
                 "derived": False,
+                "alias": "source_var",
                 "subvariables": [
                     "%s001/" % var_url,
                     "%s002/" % var_url,
@@ -6649,7 +6668,7 @@ class TestSubvariableCodes:
         ]
         expression = {
             "function": "copy_variable",
-            "args": [{"variable": var_url}],
+            "args": [{"var": "source_var"}],
             "references": {"subreferences": subreferences}
         }
         assert args == [{
@@ -6660,4 +6679,3 @@ class TestSubvariableCodes:
                 "derivation": expression,
             }
         }]
-

--- a/scrunch/tests/test_expressions.py
+++ b/scrunch/tests/test_expressions.py
@@ -106,15 +106,15 @@ class TestExpressionParsing(TestCase):
                         {
                             'function': '==',
                             'args': [
-                                {'variable': 'http://host.com/api/datasets/abc123/variables/0001/'},
+                                {'var': 'identity'},
                                 {'value': 1}
                             ]
                         },
                         {
                             'function': '<=',
                             'args': [
-                                {'variable': 'http://host.com/api/datasets/abc123/variables/0002/'},
-                                {'variable': 'http://host.com/api/datasets/abc123/variables/0003/'}
+                                {'var': 'caseid'},
+                                {'var': 'surveyid'}
                             ]
                         }
                     ]
@@ -122,7 +122,7 @@ class TestExpressionParsing(TestCase):
                 {
                     'function': '>=',
                     'args': [
-                        {'variable': 'http://host.com/api/datasets/abc123/variables/0001/'},
+                        {'var': 'identity'},
                         {'value': 2}
                     ]
                 }
@@ -160,7 +160,7 @@ class TestExpressionParsing(TestCase):
             'function': '==',
             'args': [
                 {
-                    'variable': 'age'
+                    'var': 'age'
                 },
                 {
                     'value': 1
@@ -178,7 +178,7 @@ class TestExpressionParsing(TestCase):
                     'value': 1
                 },
                 {
-                    'variable': 'age'
+                    'var': 'age'
                 }
             ]
         }
@@ -190,7 +190,7 @@ class TestExpressionParsing(TestCase):
             'function': '==',
             'args': [
                 {
-                    'variable': 'name'
+                    'var': 'name'
                 },
                 {
                     'value': 'John Doe'
@@ -208,7 +208,7 @@ class TestExpressionParsing(TestCase):
                     'value': 'John Doe'
                 },
                 {
-                    'variable': 'name'
+                    'var': 'name'
                 }
             ]
         }
@@ -220,7 +220,7 @@ class TestExpressionParsing(TestCase):
             'function': '!=',
             'args': [
                 {
-                    'variable': 'age'
+                    'var': 'age'
                 },
                 {
                     'value': 1
@@ -238,7 +238,7 @@ class TestExpressionParsing(TestCase):
                     'value': 1
                 },
                 {
-                    'variable': 'age'
+                    'var': 'age'
                 }
             ]
         }
@@ -250,7 +250,7 @@ class TestExpressionParsing(TestCase):
             'function': '!=',
             'args': [
                 {
-                    'variable': 'name'
+                    'var': 'name'
                 },
                 {
                     'value': 'John Doe'
@@ -268,7 +268,7 @@ class TestExpressionParsing(TestCase):
                     'value': 'John Doe'
                 },
                 {
-                    'variable': 'name'
+                    'var': 'name'
                 }
             ]
         }
@@ -280,7 +280,7 @@ class TestExpressionParsing(TestCase):
             'function': '<',
             'args': [
                 {
-                    'variable': 'caseid'
+                    'var': 'caseid'
                 },
                 {
                     'value': 1234
@@ -298,7 +298,7 @@ class TestExpressionParsing(TestCase):
                     'value': 1234
                 },
                 {
-                    'variable': 'caseid'
+                    'var': 'caseid'
                 }
             ]
         }
@@ -310,7 +310,7 @@ class TestExpressionParsing(TestCase):
             'function': '<=',
             'args': [
                 {
-                    'variable': 'caseid'
+                    'var': 'caseid'
                 },
                 {
                     'value': 1234
@@ -328,7 +328,7 @@ class TestExpressionParsing(TestCase):
                     'value': 1234
                 },
                 {
-                    'variable': 'caseid'
+                    'var': 'caseid'
                 }
             ]
         }
@@ -340,7 +340,7 @@ class TestExpressionParsing(TestCase):
             'function': '>',
             'args': [
                 {
-                    'variable': 'caseid'
+                    'var': 'caseid'
                 },
                 {
                     'value': 1234
@@ -358,7 +358,7 @@ class TestExpressionParsing(TestCase):
                     'value': 1234
                 },
                 {
-                    'variable': 'caseid'
+                    'var': 'caseid'
                 }
             ]
         }
@@ -370,7 +370,7 @@ class TestExpressionParsing(TestCase):
             'function': '>=',
             'args': [
                 {
-                    'variable': 'caseid'
+                    'var': 'caseid'
                 },
                 {
                     'value': 1234
@@ -388,7 +388,7 @@ class TestExpressionParsing(TestCase):
                     'value': 1234
                 },
                 {
-                    'variable': 'caseid'
+                    'var': 'caseid'
                 }
             ]
         }
@@ -400,10 +400,10 @@ class TestExpressionParsing(TestCase):
             'function': '==',
             'args': [
                 {
-                    'variable': 'starttdate'
+                    'var': 'starttdate'
                 },
                 {
-                    'variable': 'arrivedate'
+                    'var': 'arrivedate'
                 }
             ]
         }
@@ -414,10 +414,10 @@ class TestExpressionParsing(TestCase):
             'function': '!=',
             'args': [
                 {
-                    'variable': 'starttdate'
+                    'var': 'starttdate'
                 },
                 {
-                    'variable': 'arrivedate'
+                    'var': 'arrivedate'
                 }
             ]
         }
@@ -428,10 +428,10 @@ class TestExpressionParsing(TestCase):
             'function': '<',
             'args': [
                 {
-                    'variable': 'starttdate'
+                    'var': 'starttdate'
                 },
                 {
-                    'variable': 'arrivedate'
+                    'var': 'arrivedate'
                 }
             ]
         }
@@ -442,10 +442,10 @@ class TestExpressionParsing(TestCase):
             'function': '<=',
             'args': [
                 {
-                    'variable': 'starttdate'
+                    'var': 'starttdate'
                 },
                 {
-                    'variable': 'arrivedate'
+                    'var': 'arrivedate'
                 }
             ]
         }
@@ -456,10 +456,10 @@ class TestExpressionParsing(TestCase):
             'function': '>',
             'args': [
                 {
-                    'variable': 'starttdate'
+                    'var': 'starttdate'
                 },
                 {
-                    'variable': 'arrivedate'
+                    'var': 'arrivedate'
                 }
             ]
         }
@@ -470,10 +470,10 @@ class TestExpressionParsing(TestCase):
             'function': '>=',
             'args': [
                 {
-                    'variable': 'starttdate'
+                    'var': 'starttdate'
                 },
                 {
-                    'variable': 'arrivedate'
+                    'var': 'arrivedate'
                 }
             ]
         }
@@ -491,7 +491,7 @@ class TestExpressionParsing(TestCase):
                             'function': '==',
                             'args': [
                                 {
-                                    'variable': 'identity'
+                                    'var': 'identity'
                                 },
                                 {
                                     'value': 1
@@ -502,10 +502,10 @@ class TestExpressionParsing(TestCase):
                             'function': '<=',
                             'args': [
                                 {
-                                    'variable': 'caseid'
+                                    'var': 'caseid'
                                 },
                                 {
-                                    'variable': 'surveyid'
+                                    'var': 'surveyid'
                                 }
                             ]
                         }
@@ -515,7 +515,7 @@ class TestExpressionParsing(TestCase):
                     'function': '>=',
                     'args': [
                         {
-                            'variable': 'identity'
+                            'var': 'identity'
                         },
                         {
                             'value': 2
@@ -532,7 +532,7 @@ class TestExpressionParsing(TestCase):
             'function': 'in',
             'args': [
                 {
-                    'variable': 'web_browser'
+                    'var': 'web_browser'
                 },
                 {
                     'value': ['abc', 'dfg', 'hij']
@@ -547,7 +547,7 @@ class TestExpressionParsing(TestCase):
             'function': 'in',
             'args': [
                 {
-                    'variable': 'web_browser'
+                    'var': 'web_browser'
                 },
                 {
                     'value': ['abc', 'dfg', 'hij']
@@ -561,7 +561,7 @@ class TestExpressionParsing(TestCase):
             'function': 'in',
             'args': [
                 {
-                    'variable': 'country_cat'
+                    'var': 'country_cat'
                 },
                 {
                     'value': [1.0]
@@ -577,7 +577,7 @@ class TestExpressionParsing(TestCase):
             'function': 'in',
             'args': [
                 {
-                    'variable': 'country_cat'
+                    'var': 'country_cat'
                 },
                 {
                     'value': [1]
@@ -592,7 +592,7 @@ class TestExpressionParsing(TestCase):
         expected_expr_obj = {
             'args':
                 [
-                    {'variable': 'q1'},
+                    {'var': 'q1'},
                     {'value': [1, 2, 4, 5, 6, 7, 10, 11, 12]}
                 ],
             'function': 'in'
@@ -616,7 +616,7 @@ class TestExpressionParsing(TestCase):
                     'function': 'in',
                     'args': [
                         {
-                            'variable': 'country'
+                            'var': 'country'
                         },
                         {
                             'value': [1, 2, 3]
@@ -636,7 +636,7 @@ class TestExpressionParsing(TestCase):
                     'function': 'in',
                     'args': [
                         {
-                            'variable': 'country'
+                            'var': 'country'
                         },
                         {
                             'value': [1, 2, 3]
@@ -659,7 +659,7 @@ class TestExpressionParsing(TestCase):
                     'function': '==',
                     'args': [
                         {
-                            'variable': 'disposition'
+                            'var': 'disposition'
                         },
                         {
                             'value': 0
@@ -670,7 +670,7 @@ class TestExpressionParsing(TestCase):
                     'function': '==',
                     'args': [
                         {
-                            'variable': 'exit_status'
+                            'var': 'exit_status'
                         },
                         {
                             'value': 0
@@ -687,7 +687,7 @@ class TestExpressionParsing(TestCase):
             'function': 'any',
             'args': [
                 {
-                    'variable': 'Q2'
+                    'var': 'Q2'
                 },
                 {
                     'value': [1, 2, 3]
@@ -701,7 +701,7 @@ class TestExpressionParsing(TestCase):
             'function': 'any',
             'args': [
                 {
-                    'variable': 'Q2'
+                    'var': 'Q2'
                 },
                 {
                     'value': [1, 2, 3]
@@ -724,7 +724,7 @@ class TestExpressionParsing(TestCase):
             'function': 'all',
             'args': [
                 {
-                    'variable': 'Q2'
+                    'var': 'Q2'
                 },
                 {
                     'value': [1, 2, 3]
@@ -738,7 +738,7 @@ class TestExpressionParsing(TestCase):
             'function': 'all',
             'args': [
                 {
-                    'variable': 'Q2'
+                    'var': 'Q2'
                 },
                 {
                     'value': [1, 2, 3]
@@ -771,7 +771,7 @@ class TestExpressionParsing(TestCase):
                         'function': '==',
                         'args': [
                             {
-                                'variable': 'disposition'
+                                'var': 'disposition'
                             },
                             {
                                 'value': 0
@@ -782,7 +782,7 @@ class TestExpressionParsing(TestCase):
                         'function': '==',
                         'args': [
                             {
-                                'variable': 'exit_status'
+                                'var': 'exit_status'
                             },
                             {
                                 'value': 1
@@ -797,7 +797,7 @@ class TestExpressionParsing(TestCase):
                         'function': '==',
                         'args': [
                             {
-                                'variable': 'disposition'
+                                'var': 'disposition'
                             },
                             {
                                 'value': 0
@@ -808,7 +808,7 @@ class TestExpressionParsing(TestCase):
                         'function': '==',
                         'args': [
                             {
-                                'variable': 'exit_status'
+                                'var': 'exit_status'
                             },
                             {
                                 'value': 0
@@ -825,7 +825,7 @@ class TestExpressionParsing(TestCase):
         assert parsed_zcl_expr == {
             'function': 'any',
             'args': [
-                {'variable': 'MyMrVar'},
+                {'var': 'MyMrVar'},
                 {'column': ['subvar1', 'subvar2']}
             ]
         }
@@ -836,7 +836,7 @@ class TestExpressionParsing(TestCase):
         assert expr_obj == {
             'function': 'all',
             'args': [
-                {'variable': 'MyMrVar'},
+                {'var': 'MyMrVar'},
                 {'column': ['subvar1', 'subvar2']}
             ]
         }
@@ -847,7 +847,7 @@ class TestExpressionParsing(TestCase):
         assert expr_obj == {
             'function': 'in',
             'args': [
-                {'variable': 'MyMrVar'},
+                {'var': 'MyMrVar'},
                 {'column': ['subvar1', 'subvar2']}
             ]
         }
@@ -864,7 +864,7 @@ class TestExpressionParsing(TestCase):
             'function': 'any',
             'args': [
                 {
-                    'variable': 'CompanyTurnover'
+                    'var': 'CompanyTurnover'
                 },
                 {
                     'value': [99]
@@ -878,7 +878,7 @@ class TestExpressionParsing(TestCase):
             'function': 'any',
             'args': [
                 {
-                    'variable': 'sector'
+                    'var': 'sector'
                 },
                 {
                     'value': [2, 3, 98, 99]
@@ -896,7 +896,7 @@ class TestExpressionParsing(TestCase):
                     'function': '==',
                     'args': [
                         {
-                            'variable': 'age'
+                            'var': 'age'
                         },
                         {
                             'value': 1
@@ -916,7 +916,7 @@ class TestExpressionParsing(TestCase):
                     'function': 'any',
                     'args': [
                         {
-                            'variable': 'Q2'
+                            'var': 'Q2'
                         },
                         {
                             'value': [1, 2, 3]
@@ -935,7 +935,7 @@ class TestExpressionParsing(TestCase):
                     'function': 'all',
                     'args': [
                         {
-                            'variable': 'Q2'
+                            'var': 'Q2'
                         },
                         {
                             'value': [1, 2, 3]
@@ -952,7 +952,7 @@ class TestExpressionParsing(TestCase):
             'function': 'duplicates',
             'args': [
                 {
-                    'variable': 'identity'
+                    'var': 'identity'
                 }
             ]
         }
@@ -967,7 +967,7 @@ class TestExpressionParsing(TestCase):
                     'function': 'duplicates',
                     'args': [
                         {
-                            'variable': 'identity'
+                            'var': 'identity'
                         }
                     ]
                 }
@@ -993,7 +993,7 @@ class TestExpressionParsing(TestCase):
             'args': [
                 {
                     'args': [
-                        {'variable': 'age'},
+                        {'var': 'age'},
                         {'value': 1}
                     ],
                     'function': '=='
@@ -1002,14 +1002,14 @@ class TestExpressionParsing(TestCase):
                     'args': [
                         {
                             'args': [
-                                {'variable': 'test'},
+                                {'var': 'test'},
                                 {'value': 3}
                             ],
                             'function': '=='
                         },
                         {
                             'args': [
-                                {'variable': 'myop'},
+                                {'var': 'myop'},
                                 {'value': 'age'}
                             ],
                             'function': '=='
@@ -1031,14 +1031,14 @@ class TestExpressionParsing(TestCase):
                     'args': [
                         {
                             'args': [
-                                {'variable': 'var1'},
+                                {'var': 'var1'},
                                 {'value': 3}
                             ],
                             'function': '+'
                         },
                         {
                             'args': [
-                                {'variable': 'var2'},
+                                {'var': 'var2'},
                                 {'value': 2}
                             ],
                             'function': '-'}
@@ -1049,14 +1049,14 @@ class TestExpressionParsing(TestCase):
                     'args': [
                         {
                             'args': [
-                                {'variable': 'var3'},
+                                {'var': 'var3'},
                                 {'value': 1}
                             ],
                             'function': '/'
                         },
                         {
                             'args': [
-                                {'variable': 'var4'},
+                                {'var': 'var4'},
                                 {'value': 10}
                             ],
                             'function': '*'}
@@ -1077,7 +1077,7 @@ class TestExpressionParsing(TestCase):
                     'args': [
                         {
                             'args': [
-                                {'variable': 'var1'},
+                                {'var': 'var1'},
                                 {'value': 10}
                             ],
                             'function': '*'
@@ -1092,7 +1092,7 @@ class TestExpressionParsing(TestCase):
                     ],
                     'function': '+'
                 },
-                {'variable': 'var2'}
+                {'var': 'var2'}
             ],
             'function': '=='
         }
@@ -1156,7 +1156,7 @@ class TestExpressionParsing(TestCase):
                     "function": "*",
                     "args": [
                         {
-                            "variable": "weekly_rent"
+                            "var": "weekly_rent"
                         },
                         {
                             "value": 52
@@ -1177,7 +1177,7 @@ class TestExpressionParsing(TestCase):
             'function': 'is_valid',
             'args': [
                 {
-                    'variable': 'birthyear'
+                    'var': 'birthyear'
                 }
             ]
         }
@@ -1188,7 +1188,7 @@ class TestExpressionParsing(TestCase):
             'function': 'is_missing',
             'args': [
                 {
-                    'variable': 'birthyear'
+                    'var': 'birthyear'
                 }
             ]
         }
@@ -1203,7 +1203,7 @@ class TestExpressionParsing(TestCase):
                     'function': 'is_valid',
                     'args': [
                         {
-                            'variable': 'birthyear'
+                            'var': 'birthyear'
                         }
                     ]
                 }
@@ -1219,7 +1219,7 @@ class TestExpressionParsing(TestCase):
                     'function': 'is_missing',
                     'args': [
                         {
-                            'variable': 'birthyear'
+                            'var': 'birthyear'
                         }
                     ]
                 }
@@ -1236,7 +1236,7 @@ class TestExpressionParsing(TestCase):
                     'function': 'is_valid',
                     'args': [
                         {
-                            'variable': 'birthyear'
+                            'var': 'birthyear'
                         }
                     ]
                 },
@@ -1244,7 +1244,7 @@ class TestExpressionParsing(TestCase):
                     'function': 'is_valid',
                     'args': [
                         {
-                            'variable': 'birthmonth'
+                            'var': 'birthmonth'
                         }
                     ]
                 }
@@ -1260,7 +1260,7 @@ class TestExpressionParsing(TestCase):
                     'function': 'is_missing',
                     'args': [
                         {
-                            'variable': 'birthyear'
+                            'var': 'birthyear'
                         }
                     ]
                 },
@@ -1268,7 +1268,7 @@ class TestExpressionParsing(TestCase):
                     'function': 'is_missing',
                     'args': [
                         {
-                            'variable': 'birthmonth'
+                            'var': 'birthmonth'
                         }
                     ]
                 }
@@ -1288,7 +1288,7 @@ class TestExpressionParsing(TestCase):
                             'function': 'is_valid',
                             'args': [
                                 {
-                                    'variable': 'birthyear'
+                                    'var': 'birthyear'
                                 }
                             ]
                         },
@@ -1296,7 +1296,7 @@ class TestExpressionParsing(TestCase):
                             'function': 'is_valid',
                             'args': [
                                 {
-                                    'variable': 'birthmonth'
+                                    'var': 'birthmonth'
                                 }
                             ]
                         }
@@ -1317,7 +1317,7 @@ class TestExpressionParsing(TestCase):
                             'function': 'is_missing',
                             'args': [
                                 {
-                                    'variable': 'birthyear'
+                                    'var': 'birthyear'
                                 }
                             ]
                         },
@@ -1325,7 +1325,7 @@ class TestExpressionParsing(TestCase):
                             'function': 'is_missing',
                             'args': [
                                 {
-                                    'variable': 'birthmonth'
+                                    'var': 'birthmonth'
                                 }
                             ]
                         }
@@ -1344,7 +1344,7 @@ class TestExpressionParsing(TestCase):
                     'function': '<',
                     'args': [
                         {
-                            'variable': 'caseid'
+                            'var': 'caseid'
                         },
                         {
                             'value': 12345
@@ -1358,7 +1358,7 @@ class TestExpressionParsing(TestCase):
                             'function': 'is_missing',
                             'args': [
                                 {
-                                    'variable': 'birthyear'
+                                    'var': 'birthyear'
                                 }
                             ]
                         },
@@ -1366,7 +1366,7 @@ class TestExpressionParsing(TestCase):
                             'function': 'is_missing',
                             'args': [
                                 {
-                                    'variable': 'birthmonth'
+                                    'var': 'birthmonth'
                                 }
                             ]
                         }
@@ -1382,17 +1382,17 @@ class TestExpressionParsing(TestCase):
         assert expr_obj == {
             'args': [
                 {
-                    'args': [{'variable': 'year'}],
+                    'args': [{'var': 'year'}],
                     'function': 'is_missing'
                 },
                 {
                     'args': [
                         {
-                            'args': [{'variable': 'month'}],
+                            'args': [{'var': 'month'}],
                             'function': 'is_missing'
                         },
                         {
-                            'args': [{'variable': 'age'}],
+                            'args': [{'var': 'age'}],
                             'function': 'is_missing'
                         }
                     ],
@@ -1407,23 +1407,23 @@ class TestExpressionParsing(TestCase):
         assert expr_obj == {
             'args': [
                 {
-                    'args': [{'variable': 'year'}],
+                    'args': [{'var': 'year'}],
                     'function': 'is_valid'
                 },
                 {
                     'args': [
                         {
-                            'args': [{'variable': 'month'}],
+                            'args': [{'var': 'month'}],
                             'function': 'is_valid'
                         },
                         {
                             'args': [
                                 {
-                                    'args': [{'variable': 'age'}],
+                                    'args': [{'var': 'age'}],
                                     'function': 'is_valid'
                                 },
                                 {
-                                    'args': [{'variable': 'gender'}],
+                                    'args': [{'var': 'gender'}],
                                     'function': 'is_valid'
                                 }
                             ],
@@ -1446,7 +1446,7 @@ class TestExpressionParsing(TestCase):
                     'function': 'in',
                     'args': [
                         {
-                            'variable': 'a'
+                            'var': 'a'
                         },
                         {
                             'value': [1, 2, 3]
@@ -1465,7 +1465,7 @@ class TestExpressionParsing(TestCase):
                     'function': 'in',
                     'args': [
                         {
-                            'variable': 'a'
+                            'var': 'a'
                         },
                         {
                             'value': [1, 2, 3]
@@ -1484,7 +1484,7 @@ class TestExpressionParsing(TestCase):
                     'function': 'in',
                     'args': [
                         {
-                            'variable': 'a'
+                            'var': 'a'
                         },
                         {
                             'value': [1, 2, 3]
@@ -1496,7 +1496,7 @@ class TestExpressionParsing(TestCase):
 
     def test_parse_subvariable_brackets(self):
         expr = "array_alias[subvariable_alias] in [1, 2, 3]"
-        expr_obj = parse_expr(expr, platonic=False)
+        expr_obj = parse_expr(expr)
         assert expr_obj == {
             'function': 'in',
             'args': [
@@ -1504,11 +1504,11 @@ class TestExpressionParsing(TestCase):
                 # this is a temporary intern format, so we can use this later
                 # on to convert to URLs appropriately discovering first the
                 # array and then the subvariable
-                {'variable': {"array": "array_alias", "subvariable": "subvariable_alias"}},
+                {'var': "array_alias", "axes": ["subvariable_alias"]},
                 {'value': [1, 2, 3]}
             ]
         }
-        expr_obj = parse_expr(expr, platonic=True)
+        expr_obj = parse_expr(expr)
         assert expr_obj == {
             'function': 'in',
             'args': [
@@ -1523,7 +1523,7 @@ class TestExpressionParsing(TestCase):
 
     def test_parse_platonic_expr(self):
         expr = """not (array[subvar] or num_val) and other[dimension] and not logical"""
-        parsed = parse_expr(expr, platonic=True)
+        parsed = parse_expr(expr)
         assert parsed == {
             'function': 'and',
             'args': [
@@ -1650,7 +1650,7 @@ class TestExpressionProcessing(TestCase):
             'function': '==',
             'args': [
                 {
-                    'variable': var_url
+                    'var': var_alias
                 },
                 {
                     'value': 1
@@ -1665,10 +1665,10 @@ class TestExpressionProcessing(TestCase):
         var_type = 'multiple_response'
         var_url = '{}variables/{}/'.format(self.ds_url, var_id)
         var_categories = [
-                    {"id": 1, "name": "cat1", "selected": True},
-                    {"id": 2, "name": "cat2", "selected": True},
-                    {"id": 3, "name": "cat3", "selected": False},
-                ]
+            {"id": 1, "name": "cat1", "selected": True},
+            {"id": 2, "name": "cat2", "selected": True},
+            {"id": 3, "name": "cat3", "selected": False},
+        ]
 
         table_mock = mock.MagicMock(metadata={
             var_id: {
@@ -1695,7 +1695,7 @@ class TestExpressionProcessing(TestCase):
                 "name": "Multiple Response",
                 "description": "",
                 "notes": "",
-                "alias": "mr_variable",
+                "alias": var_alias,
                 "id": "{}".format(var_id),
                 "type": "multiple_response",
                 "subvariables": [
@@ -1711,10 +1711,11 @@ class TestExpressionProcessing(TestCase):
         with mock.patch("scrunch.expressions.get_subvariables_resource") as mock_subvars, mock.patch("scrunch.expressions._get_categories_from_var_index") as categories:
             categories.return_value = var_categories
             mock_subvars.return_value = dict(sorted({"subvar1": "001", "subvar2": "002", "subvar3": "003"}.items()))
-            result, need_wrap = adapt_multiple_response(var_url, values, ds.variables.index)
+            vars_by_alias = {v['alias']: v for _, v in ds.variables.index.items()}
+            result, need_wrap = adapt_multiple_response(var_alias, values, vars_by_alias)
             assert result == [
-                {'variable': "{}subvariables/001/".format(var_url), 'column': [1, 2]},
-                {'variable': "{}subvariables/002/".format(var_url), 'column': [1, 2]}
+                {'var': var_alias, 'axes': ['subvar1'], 'column': [1, 2]},
+                {'var': var_alias, 'axes': ['subvar2'], 'column': [1, 2]}
             ]
             assert need_wrap is True
 
@@ -1920,7 +1921,7 @@ class TestExpressionProcessing(TestCase):
                 "name": "Multiple Response",
                 "description": "",
                 "notes": "",
-                "alias": "mr_variable",
+                "alias": var_alias,
                 "id": "{}".format(var_id),
                 "type": "multiple_response",
                 "subvariables": [
@@ -1960,7 +1961,8 @@ class TestExpressionProcessing(TestCase):
             'function': 'in',
             'args': [
                 {
-                    'variable': 'http://test.crunch.io/api/datasets/123/variables/0001/subvariables/001/'
+                    'var': 'MyMrVar',
+                    'axes': ['subvar1']
                 },
                 {
                     'column': [1]
@@ -2005,7 +2007,7 @@ class TestExpressionProcessing(TestCase):
                 "name": "Multiple Response",
                 "description": "",
                 "notes": "",
-                "alias": "mr_variable",
+                "alias": var_alias,
                 "id": "{}".format(var_id),
                 "type": "multiple_response",
                 "subvariables": [
@@ -2047,7 +2049,8 @@ class TestExpressionProcessing(TestCase):
                     'function': 'in',
                     'args': [
                         {
-                            'variable': 'http://test.crunch.io/api/datasets/123/variables/0001/subvariables/001/'
+                            'var': 'MyMrVar',
+                            'axes': ['subvar1']
                         },
                         {
                             'column': [1]
@@ -2058,7 +2061,8 @@ class TestExpressionProcessing(TestCase):
                     'function': 'in',
                     'args': [
                         {
-                            'variable': 'http://test.crunch.io/api/datasets/123/variables/0001/subvariables/002/'
+                            'var': 'MyMrVar',
+                            'axes': ['subvar2']
                         },
                         {
                             'column': [1]
@@ -2141,7 +2145,8 @@ class TestExpressionProcessing(TestCase):
             'function': '==',
             'args': [
                 {
-                    'variable': "{}subvariables/001/".format(var_url),
+                    'var': var_alias,
+                    'axes': ['subvar1']
                 },
                 {
                     'value': 1
@@ -2184,7 +2189,8 @@ class TestExpressionProcessing(TestCase):
             'function': '==',
             'args': [
                 {
-                    'variable': '%ssubvariables/%s/' % (var_url, subvariables[0])
+                    'var': var_alias,
+                    'axes': ['hobbies_1']
                 },
                 {
                     'value': 4
@@ -2217,7 +2223,7 @@ class TestExpressionProcessing(TestCase):
 
         # Expression with subvariable indicated by bracket syntax
         expr = "hobbies_array[hobbies_1] == 4"
-        parsed_platonic = parse_expr(expr, platonic=True)
+        parsed_platonic = parse_expr(expr)
         assert parsed_platonic == {
             'function': '==',
             'args': [
@@ -2231,7 +2237,7 @@ class TestExpressionProcessing(TestCase):
             'function': '==',
             'args': [
                 # Stores a reference to the pieces of the array/subvariable
-                {"variable": {"array": 'hobbies_array', "subvariable": 'hobbies_1'}},
+                {"var": 'hobbies_array', "axes": ['hobbies_1']},
                 {'value': 4}
             ]
         }
@@ -2240,14 +2246,14 @@ class TestExpressionProcessing(TestCase):
             'function': '==',
             'args': [
                 # Correctly translates into the subvariable URL
-                {'variable': subvariable_url},
+                {'var': 'hobbies_array', 'axes': ['hobbies_1']},
                 {'value': 4}
             ]
         }
 
         # Expression with subvariable indicated by bracket syntax
         expr = "hobbies_array[hobbies_1].any([1, 2])"
-        parsed_platonic = parse_expr(expr, platonic=True)
+        parsed_platonic = parse_expr(expr)
         assert parsed_platonic == {
             'function': "any",
             'args': [
@@ -2261,7 +2267,7 @@ class TestExpressionProcessing(TestCase):
             'function': "any",
             'args': [
                 # Stores a reference to the array/subvairable
-                {"variable": {"array": 'hobbies_array', "subvariable": 'hobbies_1'}},
+                {"var": 'hobbies_array', "axes": ['hobbies_1']},
                 {'value': [1, 2]}
             ]
         }
@@ -2270,14 +2276,14 @@ class TestExpressionProcessing(TestCase):
             'function': "in",
             'args': [
                 # Still finds the correct subvariable ID under the array URL
-                {'variable': subvariable_url},
+                {'var': 'hobbies_array', 'axes': ['hobbies_1']},
                 {'value': [1, 2]}
             ]
         }
 
         # `IN` functions have a bit of a special treatment.
         expr = "hobbies_array[hobbies_1] in [1]"
-        parsed_platonic = parse_expr(expr, platonic=True)
+        parsed_platonic = parse_expr(expr)
         assert parsed_platonic == {
             'function': 'in',
             'args': [
@@ -2291,7 +2297,7 @@ class TestExpressionProcessing(TestCase):
             'function': 'in',
             'args': [
                 # Stores a reference to the pieces of the array/subvariable
-                {"variable": {"array": 'hobbies_array', "subvariable": 'hobbies_1'}},
+                {"var": 'hobbies_array', "axes": ['hobbies_1']},
                 {'value': [1]}
             ]
         }
@@ -2300,7 +2306,7 @@ class TestExpressionProcessing(TestCase):
             'function': 'in',
             'args': [
                 # Correctly translates into the subvariable URL
-                {'variable': subvariable_url},
+                {'var': 'hobbies_array', 'axes': ['hobbies_1']},
                 {'value': [1]}
             ]
         }
@@ -2330,7 +2336,7 @@ class TestExpressionProcessing(TestCase):
 
         # Expression with subvariable indicated by bracket syntax
         expr = "hobbies_array[hobbies_1] == 4"
-        parsed = parse_expr(expr, platonic=True)
+        parsed = parse_expr(expr)
         assert parsed == {
             'function': '==',
             'args': [
@@ -2342,12 +2348,12 @@ class TestExpressionProcessing(TestCase):
         expr_obj = process_expr(parsed, ds)
         assert expr_obj == parsed
 
-        parsed = parse_expr(expr, platonic=False)
+        parsed = parse_expr(expr)
         assert parsed == {
             'function': '==',
             'args': [
                 # Keeps the platonic reference to the subvariable
-                {"variable": {"array": 'hobbies_array', "subvariable": 'hobbies_1'}},
+                {"var": 'hobbies_array', "axes": ['hobbies_1']},
                 {'value': 4}
             ]
         }
@@ -2356,7 +2362,7 @@ class TestExpressionProcessing(TestCase):
             'function': '==',
             'args': [
                 # Keeps the platonic reference to the subvariable
-                {"variable": subvariable_url},
+                {"var": 'hobbies_array', "axes": ['hobbies_1']},
                 {'value': 4}
             ]
         }
@@ -2394,7 +2400,8 @@ class TestExpressionProcessing(TestCase):
             'function': 'in',
             'args': [
                 {
-                    'variable': '%ssubvariables/%s/' % (var_url, subvariables[0])
+                    'var': 'hobbies',
+                    'axes': ['hobbies_1']
                 },
                 {
                     'value': [32766]
@@ -2434,7 +2441,8 @@ class TestExpressionProcessing(TestCase):
             'function': '==',
             'args': [
                 {
-                    'variable': '%ssubvariables/%s/' % (var_url, subvariables[0])
+                    'var': 'hobbies',
+                    'axes': ['hobbies_1']
                 },
                 {
                     'value': 32766
@@ -2478,7 +2486,8 @@ class TestExpressionProcessing(TestCase):
                     'function': 'in',
                     'args': [
                         {
-                            'variable': '%ssubvariables/%s/' % (var_url, subvariables[0])
+                            'var': 'hobbies',
+                            'axes': ['hobbies_1']
                         },
                         {
                             'value': [32766]
@@ -2524,7 +2533,7 @@ class TestExpressionProcessing(TestCase):
                     'function': '==',
                     'args': [
                         {
-                            'variable': '%ssubvariables/%s/' % (var_url, subvariables[0])
+                            'var': 'hobbies', 'axes': ['hobbies_1']
                         },
                         {
                             'value': 32766
@@ -2568,7 +2577,8 @@ class TestExpressionProcessing(TestCase):
             'function': 'in',
             'args': [
                 {
-                    'variable': '%ssubvariables/%s/' % (var_url, subvariables[0])
+                    'var': 'hobbies',
+                    'axes': ['hobbies_1']
                 },
                 {
                     'value': [32766, 32767]
@@ -2647,7 +2657,8 @@ class TestExpressionProcessing(TestCase):
                     'function': 'in',
                     'args': [
                         {
-                            'variable': '%ssubvariables/%s/' % (var_url, subvariables[0])
+                            'var': 'hobbies',
+                            'axes': ['hobbies_1'],
                         },
                         {
                             'value': [32766]
@@ -2658,7 +2669,8 @@ class TestExpressionProcessing(TestCase):
                     'function': 'in',
                     'args': [
                         {
-                            'variable': '%ssubvariables/%s/' % (var_url, subvariables[1])
+                            'var': 'hobbies',
+                            'axes': ['hobbies_2'],
                         },
                         {
                             'value': [32766]
@@ -2669,7 +2681,8 @@ class TestExpressionProcessing(TestCase):
                     'function': 'in',
                     'args': [
                         {
-                            'variable': '%ssubvariables/%s/' % (var_url, subvariables[2])
+                            'var': 'hobbies',
+                            'axes': ['hobbies_3'],
                         },
                         {
                             'value': [32766]
@@ -2680,7 +2693,8 @@ class TestExpressionProcessing(TestCase):
                     'function': 'in',
                     'args': [
                         {
-                            'variable': '%ssubvariables/%s/' % (var_url, subvariables[3])
+                            'var': 'hobbies',
+                            'axes': ['hobbies_4'],
                         },
                         {
                             'value': [32766]
@@ -2731,7 +2745,8 @@ class TestExpressionProcessing(TestCase):
                     'function': '==',
                     'args': [
                         {
-                            'variable': '%ssubvariables/%s/' % (var_url, subvariables[0])
+                            'var': 'hobbies',
+                            'axes': ['hobbies_1'],
                         },
                         {
                             'value': 32766
@@ -2742,7 +2757,8 @@ class TestExpressionProcessing(TestCase):
                     'function': '==',
                     'args': [
                         {
-                            'variable': '%ssubvariables/%s/' % (var_url, subvariables[1])
+                            'var': 'hobbies',
+                            'axes': ['hobbies_2'],
                         },
                         {
                             'value': 32766
@@ -2753,7 +2769,8 @@ class TestExpressionProcessing(TestCase):
                     'function': '==',
                     'args': [
                         {
-                            'variable': '%ssubvariables/%s/' % (var_url, subvariables[2])
+                            'var': 'hobbies',
+                            'axes': ['hobbies_3'],
                         },
                         {
                             'value': 32766
@@ -2764,7 +2781,8 @@ class TestExpressionProcessing(TestCase):
                     'function': '==',
                     'args': [
                         {
-                            'variable': '%ssubvariables/%s/' % (var_url, subvariables[3])
+                            'var': 'hobbies',
+                            'axes': ['hobbies_4'],
                         },
                         {
                             'value': 32766
@@ -2819,7 +2837,8 @@ class TestExpressionProcessing(TestCase):
                              'function': 'in',
                              'args': [
                                 {
-                                     'variable': '%ssubvariables/%s/' % (var_url, subvariables[0])
+                                     'var': 'hobbies',
+                                     'axes': ['hobbies_1'],
                                 },
                                  {
                                      'value': [32766]
@@ -2830,7 +2849,8 @@ class TestExpressionProcessing(TestCase):
                              'function': 'in',
                              'args': [
                                  {
-                                     'variable': '%ssubvariables/%s/' % (var_url, subvariables[1])
+                                     'var': 'hobbies',
+                                     'axes': ['hobbies_2'],
                                  },
                                  {
                                      'value': [32766]
@@ -2841,7 +2861,8 @@ class TestExpressionProcessing(TestCase):
                              'function': 'in',
                              'args': [
                                  {
-                                     'variable': '%ssubvariables/%s/' % (var_url, subvariables[2])
+                                     'var': 'hobbies',
+                                     'axes': ['hobbies_3'],
                                  },
                                  {
                                      'value': [32766]
@@ -2852,7 +2873,8 @@ class TestExpressionProcessing(TestCase):
                              'function': 'in',
                              'args': [
                                  {
-                                     'variable': '%ssubvariables/%s/' % (var_url, subvariables[3])
+                                     'var': 'hobbies',
+                                     'axes': ['hobbies_4'],
                                  },
                                  {
                                      'value': [32766]
@@ -2908,7 +2930,8 @@ class TestExpressionProcessing(TestCase):
                             'function': '==',
                             'args': [
                                 {
-                                    'variable': '%ssubvariables/%s/' % (var_url, subvariables[0])
+                                    'var': 'hobbies',
+                                    'axes': ['hobbies_1'],
                                 },
                                 {
                                     'value': 32766
@@ -2919,7 +2942,8 @@ class TestExpressionProcessing(TestCase):
                             'function': '==',
                             'args': [
                                 {
-                                    'variable': '%ssubvariables/%s/' % (var_url, subvariables[1])
+                                    'var': 'hobbies',
+                                    'axes': ['hobbies_2'],
                                 },
                                 {
                                     'value': 32766
@@ -2930,7 +2954,8 @@ class TestExpressionProcessing(TestCase):
                             'function': '==',
                             'args': [
                                 {
-                                    'variable': '%ssubvariables/%s/' % (var_url, subvariables[2])
+                                    'var': 'hobbies',
+                                    'axes': ['hobbies_3'],
                                 },
                                 {
                                     'value': 32766
@@ -2941,7 +2966,8 @@ class TestExpressionProcessing(TestCase):
                             'function': '==',
                             'args': [
                                 {
-                                    'variable': '%ssubvariables/%s/' % (var_url, subvariables[3])
+                                    'var': 'hobbies',
+                                    'axes': ['hobbies_4'],
                                 },
                                 {
                                     'value': 32766
@@ -2995,7 +3021,8 @@ class TestExpressionProcessing(TestCase):
                     'function': 'in',
                     'args': [
                         {
-                            'variable': '%ssubvariables/%s/' % (var_url, subvariables[0])
+                            'var': 'hobbies',
+                            'axes': ['hobbies_1'],
                         },
                         {
                             'value': [32766, 32767]
@@ -3006,7 +3033,8 @@ class TestExpressionProcessing(TestCase):
                     'function': 'in',
                     'args': [
                         {
-                            'variable': '%ssubvariables/%s/' % (var_url, subvariables[1])
+                            'var': 'hobbies',
+                            'axes': ['hobbies_2'],
                         },
                         {
                             'value': [32766, 32767]
@@ -3017,7 +3045,8 @@ class TestExpressionProcessing(TestCase):
                     'function': 'in',
                     'args': [
                         {
-                            'variable': '%ssubvariables/%s/' % (var_url, subvariables[2])
+                            'var': 'hobbies',
+                            'axes': ['hobbies_3'],
                         },
                         {
                             'value': [32766, 32767]
@@ -3028,7 +3057,8 @@ class TestExpressionProcessing(TestCase):
                     'function': 'in',
                     'args': [
                         {
-                            'variable': '%ssubvariables/%s/' % (var_url, subvariables[3])
+                            'var': 'hobbies',
+                            'axes': ['hobbies_4'],
                         },
                         {
                             'value': [32766, 32767]
@@ -3083,7 +3113,8 @@ class TestExpressionProcessing(TestCase):
                             'function': 'in',
                             'args': [
                                 {
-                                    'variable': '%ssubvariables/%s/' % (var_url, subvariables[0])
+                                    'var': 'hobbies',
+                                    'axes': ['hobbies_1'],
                                 },
                                 {
                                     'value': [32766, 32767]
@@ -3094,7 +3125,8 @@ class TestExpressionProcessing(TestCase):
                             'function': 'in',
                             'args': [
                                 {
-                                    'variable': '%ssubvariables/%s/' % (var_url, subvariables[1])
+                                    'var': 'hobbies',
+                                    'axes': ['hobbies_2'],
                                 },
                                 {
                                     'value': [32766, 32767]
@@ -3105,7 +3137,8 @@ class TestExpressionProcessing(TestCase):
                             'function': 'in',
                             'args': [
                                 {
-                                    'variable': '%ssubvariables/%s/' % (var_url, subvariables[2])
+                                    'var': 'hobbies',
+                                    'axes': ['hobbies_3'],
                                 },
                                 {
                                     'value': [32766, 32767]
@@ -3116,7 +3149,8 @@ class TestExpressionProcessing(TestCase):
                             'function': 'in',
                             'args': [
                                 {
-                                    'variable': '%ssubvariables/%s/' % (var_url, subvariables[3])
+                                    'var': 'hobbies',
+                                    'axes': ['hobbies_4'],
                                 },
                                 {
                                     'value': [32766, 32767]
@@ -3167,7 +3201,7 @@ class TestExpressionProcessing(TestCase):
             'function': 'all_valid',
             'args': [
                 {
-                    'variable': var_url
+                    'var': var_alias
                 }
             ]
         }
@@ -3181,7 +3215,7 @@ class TestExpressionProcessing(TestCase):
                     'function': 'all_valid',
                     'args': [
                         {
-                            'variable': var_url
+                            'var': var_alias
                         }
                     ]
                 }
@@ -3194,7 +3228,7 @@ class TestExpressionProcessing(TestCase):
             'function': 'is_missing',
             'args': [
                 {
-                    'variable': var_url
+                    'var': var_alias
                 }
             ]
         }
@@ -3208,7 +3242,7 @@ class TestExpressionProcessing(TestCase):
                     'function': 'is_missing',
                     'args': [
                         {
-                            'variable': var_url
+                            'var': var_alias
                         }
                     ]
                 }
@@ -3245,7 +3279,7 @@ class TestExpressionProcessing(TestCase):
             'function': '==',
             'args': [
                 {
-                    'variable': var_url
+                    'var': var_alias
                 },
                 {
                     'value': 1
@@ -3287,7 +3321,7 @@ class TestExpressionProcessing(TestCase):
             'function': 'in',
             'args': [
                 {
-                    'variable': var_url
+                    'var': 'hobbies'
                 },
                 {
                     'value': [1, 2]
@@ -3329,7 +3363,7 @@ class TestExpressionProcessing(TestCase):
             'function': 'in',
             'args': [
                 {
-                    'variable': var_url
+                    'var': var_alias
                 },
                 {
                     'value': [1, 2]
@@ -3372,7 +3406,7 @@ class TestExpressionProcessing(TestCase):
             'function': 'in',
             'args': [
                 {
-                    'variable': var_url
+                    'var': var_alias
                 },
                 {
                     'value': [1]
@@ -3414,7 +3448,7 @@ class TestExpressionProcessing(TestCase):
             'function': 'in',
             'args': [
                 {
-                    'variable': var_url
+                    'var': var_alias
                 },
                 {
                     'value': [1]
@@ -3457,7 +3491,7 @@ class TestExpressionProcessing(TestCase):
             'function': 'in',
             'args': [
                 {
-                    'variable': var_url
+                    'var': var_alias
                 },
                 {
                     'value': [1.0]
@@ -3507,7 +3541,7 @@ class TestExpressionPrettify(TestCase):
             "function": "in",
             "args": [
                 {
-                    "variable": "my_var"
+                    "var": "my_var"
                 },
                 {
                     "value": [
@@ -3523,7 +3557,7 @@ class TestExpressionPrettify(TestCase):
             "function": "in",
             "args": [
                 {
-                    "variable": "my_var"
+                    "var": "my_var"
                 },
                 {
                     "value": [
@@ -3542,7 +3576,7 @@ class TestExpressionPrettify(TestCase):
                     'function': '>',
                     'args': [
                         {
-                            'variable': 'age'
+                            'var': 'age'
                         },
                         {
                             'value': 1
@@ -3553,7 +3587,7 @@ class TestExpressionPrettify(TestCase):
                     'function': '==',
                     'args': [
                         {
-                            'variable': 'favcolor'
+                            'var': 'favcolor'
                         },
                         {
                             'value': 2
@@ -3575,7 +3609,7 @@ class TestExpressionPrettify(TestCase):
                     'function': '>',
                     'args': [
                         {
-                            'variable': 'age'
+                            'var': 'age'
                         },
                         {
                             'value': 1
@@ -3589,7 +3623,7 @@ class TestExpressionPrettify(TestCase):
                             'function': '==',
                             'args': [
                                 {
-                                    'variable': 'favcolor'
+                                    'var': 'favcolor'
                                 },
                                 {
                                     'value': 2
@@ -3600,7 +3634,7 @@ class TestExpressionPrettify(TestCase):
                             'function': '==',
                             'args': [
                                 {
-                                    'variable': 'genre'
+                                    'var': 'genre'
                                 },
                                 {
                                     'value': 1
@@ -3624,7 +3658,7 @@ class TestExpressionPrettify(TestCase):
                     'function': '>',
                     'args': [
                         {
-                            'variable': 'age'
+                            'var': 'age'
                         },
                         {
                             'value': 55
@@ -3641,7 +3675,7 @@ class TestExpressionPrettify(TestCase):
                                     'function': '==',
                                     'args': [
                                         {
-                                            'variable': 'genre'
+                                            'var': 'genre'
                                         },
                                         {
                                             'value': 1
@@ -3652,7 +3686,7 @@ class TestExpressionPrettify(TestCase):
                                     'function': '==',
                                     'args': [
                                         {
-                                            'variable': 'favfruit'
+                                            'var': 'favfruit'
                                         },
                                         {
                                             'value': 9
@@ -3665,7 +3699,7 @@ class TestExpressionPrettify(TestCase):
                             'function': 'in',
                             'args': [
                                 {
-                                    'variable': 'favcolor'
+                                    'var': 'favcolor'
                                 },
                                 {
                                     'value': [3, 4, 5]
@@ -3681,12 +3715,12 @@ class TestExpressionPrettify(TestCase):
         cel = prettify(expr)
         assert expected == cel
 
-    def test_variable_url(self):
+    def test_variable_alias(self):
         expr = {
             'function': '==',
             'args': [
                 {
-                    'variable': 'https://host.com/api/datasets/123/variables/001/'
+                    'var': 'age'
                 },
                 {
                     'value': 1
@@ -3704,15 +3738,14 @@ class TestExpressionPrettify(TestCase):
         expected = 'age == 1'
         cel = prettify(expr, ds)
         assert expected == cel
-        ds.resource.session.get.assert_called_with('https://host.com/api/datasets/123/variables/001/')
 
     def test_square_bracket_subvariables(self):
-        subvariable_url = 'https://host.com/api/datasets/123/variables/001/subvariables/abc/'
         expr = {
             'function': '==',
             'args': [
                 {
-                    'variable': subvariable_url
+                    'var': 'array_alias',
+                    'axes': ['sv_1']
                 },
                 {
                     'value': 1
@@ -3734,10 +3767,10 @@ class TestExpressionPrettify(TestCase):
 
         # Prepare array
         response2 = mock.MagicMock()
-        response2.payload.body = {"alias": 'array_variable'}
+        response2.payload.body = {"alias": 'array_alias'}
         ds.resource.session.get.side_effect = [response1, response2]
 
-        expected = 'array_variable[subvar_1] == 1'
+        expected = 'array_alias[sv_1] == 1'
         assert prettify(expr, ds) == expected
 
     def test_variable_url_no_dataset(self):
@@ -3745,7 +3778,7 @@ class TestExpressionPrettify(TestCase):
             'function': '==',
             'args': [
                 {
-                    'variable': 'https://host.com/api/datasets/123/variables/001/'
+                    'var': 'var_alias'
                 },
                 {
                     'value': 1
@@ -3753,13 +3786,8 @@ class TestExpressionPrettify(TestCase):
             ]
         }
 
-        with pytest.raises(Exception) as err:
-            prettify(expr)
+        assert prettify(expr) == "var_alias == 1"
 
-        assert str(err.value) == (
-            'Valid Dataset instance is required to resolve variable urls '
-            'in the expression'
-        )
 
     def test_parse_equal_string(self):
         expr_obj = {
@@ -4438,7 +4466,7 @@ class TestDatetimeStrings(TestCase):
             "function": "<",
             "args": [
                 {
-                    "variable": "starttime"
+                    "var": "starttime"
                 },
                 {
                     "value": "2016-12-21T12:00:00+00:00"
@@ -4452,7 +4480,7 @@ class TestDatetimeStrings(TestCase):
             "function": "<",
             "args": [
                 {
-                    "variable": "starttime"
+                    "var": "starttime"
                 },
                 {
                     "value": "2016-12-21T12:00:00"
@@ -4466,7 +4494,7 @@ class TestDatetimeStrings(TestCase):
             "function": "<",
             "args": [
                 {
-                    "variable": "starttime"
+                    "var": "starttime"
                 },
                 {
                     "value": "2016-12-21T12:00:00"
@@ -4480,7 +4508,7 @@ class TestDatetimeStrings(TestCase):
             "function": "<",
             "args": [
                 {
-                    "variable": "starttime"
+                    "var": "starttime"
                 },
                 {
                     "value": "2016-12-21T12:00"
@@ -4494,7 +4522,7 @@ class TestDatetimeStrings(TestCase):
             "function": "<",
             "args": [
                 {
-                    "variable": "starttime"
+                    "var": "starttime"
                 },
                 {
                     "value": "2016-12-21T12"
@@ -4508,7 +4536,7 @@ class TestDatetimeStrings(TestCase):
             "function": "<",
             "args": [
                 {
-                    "variable": "starttime"
+                    "var": "starttime"
                 },
                 {
                     "value": "2016-12-21"
@@ -4522,7 +4550,7 @@ class TestDatetimeStrings(TestCase):
             "function": "<",
             "args": [
                 {
-                    "variable": "starttime"
+                    "var": "starttime"
                 },
                 {
                     "value": "2016-12"
@@ -4536,7 +4564,7 @@ class TestDatetimeStrings(TestCase):
             "function": "<",
             "args": [
                 {
-                    "variable": "starttime"
+                    "var": "starttime"
                 },
                 {
                     "value": "2016"
@@ -4575,7 +4603,6 @@ class TestDateTimeExpression(TestCase):
         var_id = '0001'
         var_alias = 'starttime'
         var_type = 'datetime'
-        var_url = '%svariables/%s/' % (self.ds_url, var_id)
         ds = self.mock_dataset(var_id, var_alias, var_type)
         expr = "starttime < '2016-12-21'"
         parsed = parse_expr(expr)
@@ -4584,7 +4611,7 @@ class TestDateTimeExpression(TestCase):
             'function': '<',
             'args': [
                 {
-                    'variable': var_url
+                    'var': var_alias
                 },
                 {
                     'value': '2016-12-21'

--- a/scrunch/tests/test_expressions.py
+++ b/scrunch/tests/test_expressions.py
@@ -1719,6 +1719,39 @@ class TestExpressionProcessing(TestCase):
             ]
             assert need_wrap is True
 
+    def test_adapt_multiple_response_any_category_id(self):
+        var_alias = 'MyMrVar'
+        vars_by_alias = {
+            var_alias: {
+                "alias": var_alias,
+                "type": "multiple_response",
+                "entity": {
+                    "subvariables": {
+                        "index": {
+                            "001": {"id": "001", "alias": "subvar1"},
+                            "002": {"id": "002", "alias": "subvar2"},
+                            "003": {"id": "003", "alias": "subvar3"},
+                        }
+                    }
+                }
+            }
+        }
+
+        with mock.patch("scrunch.expressions.get_subvariables_resource") as mock_subvars:
+            mock_subvars.return_value = {
+                "subvar1": "001",
+                "subvar2": "002",
+                "subvar3": "003",
+            }
+            result, need_wrap = adapt_multiple_response(var_alias, [1], vars_by_alias)
+
+        assert result == [
+            {'var': var_alias, 'axes': ['subvar1'], 'column': [1]},
+            {'var': var_alias, 'axes': ['subvar2'], 'column': [1]},
+            {'var': var_alias, 'axes': ['subvar3'], 'column': [1]},
+        ]
+        assert need_wrap is True
+
     def test_process_all_multiple_response(self):
         var_id = '0001'
         var_alias = 'MyMrVar'
@@ -1736,14 +1769,14 @@ class TestExpressionProcessing(TestCase):
                 'alias': var_alias,
                 'type': var_type,
                 "subvariables": [
-                    "%ssubvariables/001/" % var_url,
-                    "%ssubvariables/002/" % var_url,
-                    "%ssubvariables/003/" % var_url,
+                    "001",
+                    "002",
+                    "003",
                 ],
                 "subreferences": {
-                    "%ssubvariables/001/" % var_url: {"alias": "subvar1"},
-                    "%ssubvariables/002/" % var_url: {"alias": "subvar2"},
-                    "%ssubvariables/003/" % var_url: {"alias": "subvar3"},
+                    "001": {"alias": "subvar1"},
+                    "002": {"alias": "subvar2"},
+                    "003": {"alias": "subvar3"},
                 },
                 "categories": var_categories
             }
@@ -1755,14 +1788,23 @@ class TestExpressionProcessing(TestCase):
                 "name": "Multiple Response",
                 "description": "",
                 "notes": "",
-                "alias": "mr_variable",
+                "alias": var_alias,
                 "id": "{}".format(var_id),
                 "type": "multiple_response",
                 "subvariables": [
-                    "{}subvariables/001/".format(var_url),
-                    "{}subvariables/002/".format(var_url),
-                    "{}subvariables/003/".format(var_url),
+                    "001",
+                    "002",
+                    "003",
                 ],
+                "entity": {
+                    "subvariables": {
+                        "index": {
+                            "001": {"id": "001", "alias": "subvar1"},
+                            "002": {"id": "002", "alias": "subvar2"},
+                            "003": {"id": "003", "alias": "subvar3"},
+                        }
+                    }
+                }
             }
         }
 
@@ -1774,36 +1816,34 @@ class TestExpressionProcessing(TestCase):
             mock_subvars.return_value = dict(sorted({"subvar1": "001", "subvar2": "002", "subvar3": "003"}.items()))
             parsed_expr = parse_expr(expr)
             processed_zcl_expr = process_expr(parsed_expr, ds)
-            assert sorted(processed_zcl_expr) == sorted({
+            assert processed_zcl_expr == {
                 'function': 'and',
                 'args': [
                     {
                         'function': '==',
                         'args': [
-                            {'variable': "{}subvariables/001/".format(var_url)},
+                            {'var': var_alias, 'axes': ['subvar1']},
                             {'value': 1}
                         ],
                     },
                     {
                         'function': '==',
                         'args': [
-                            {'variable': "{}subvariables/002/".format(var_url)},
+                            {'var': var_alias, 'axes': ['subvar2']},
                             {'value': 1}
                         ],
                     },
                     {
                         'function': '==',
                         'args': [
-                            {'variable': "{}subvariables/003/".format(var_url)},
+                            {'var': var_alias, 'axes': ['subvar3']},
                             {'value': 1}
                         ],
                     }
                 ],
-            })
+            }
 
-    @pytest.mark.xfail(reason="multiple response with `in` is not yet supported")
     def test_process_in_multiple_response(self):
-        # TODO: check how to handle this scenario in future releases. This should work as .any
         var_id = '0001'
         var_alias = 'MyMrVar'
         var_type = 'multiple_response'
@@ -1820,14 +1860,14 @@ class TestExpressionProcessing(TestCase):
                 'alias': var_alias,
                 'type': var_type,
                 "subvariables": [
-                    "%ssubvariables/001/" % var_url,
-                    "%ssubvariables/002/" % var_url,
-                    "%ssubvariables/003/" % var_url,
+                    "001",
+                    "002",
+                    "003",
                 ],
                 "subreferences": {
-                    "%ssubvariables/001/" % var_url: {"alias": "subvar1"},
-                    "%ssubvariables/002/" % var_url: {"alias": "subvar2"},
-                    "%ssubvariables/003/" % var_url: {"alias": "subvar3"},
+                    "001": {"alias": "subvar1"},
+                    "002": {"alias": "subvar2"},
+                    "003": {"alias": "subvar3"},
                 },
                 "categories": var_categories
             }
@@ -1839,14 +1879,23 @@ class TestExpressionProcessing(TestCase):
                 "name": "Multiple Response",
                 "description": "",
                 "notes": "",
-                "alias": "mr_variable",
+                "alias": var_alias,
                 "id": "{}".format(var_id),
                 "type": "multiple_response",
                 "subvariables": [
-                    "{}subvariables/001/".format(var_url),
-                    "{}subvariables/002/".format(var_url),
-                    "{}subvariables/003/".format(var_url),
+                    "001",
+                    "002",
+                    "003",
                 ],
+                "entity": {
+                    "subvariables": {
+                        "index": {
+                            "001": {"id": "001", "alias": "subvar1"},
+                            "002": {"id": "002", "alias": "subvar2"},
+                            "003": {"id": "003", "alias": "subvar3"},
+                        }
+                    }
+                }
             }
         }
 
@@ -1864,21 +1913,21 @@ class TestExpressionProcessing(TestCase):
                     {
                         'function': 'in',
                         'args': [
-                            {'variable': "{}subvariables/001/".format(var_url)},
+                            {'var': var_alias, 'axes': ['subvar1']},
                             {'column': [1]}
                         ],
                     },
                     {
                         'function': 'in',
                         'args': [
-                            {'variable': "{}subvariables/002/".format(var_url)},
+                            {'var': var_alias, 'axes': ['subvar2']},
                             {'column': [1]}
                         ],
                     },
                     {
                         'function': 'in',
                         'args': [
-                            {'variable': "{}subvariables/003/".format(var_url)},
+                            {'var': var_alias, 'axes': ['subvar3']},
                             {'column': [1]}
                         ],
                     }

--- a/scrunch/tests/test_expressions.py
+++ b/scrunch/tests/test_expressions.py
@@ -3715,7 +3715,7 @@ class TestExpressionPrettify(TestCase):
         cel = prettify(expr)
         assert expected == cel
 
-    def test_variable_alias(self):
+    def test_var_alias(self):
         expr = {
             'function': '==',
             'args': [
@@ -3739,7 +3739,32 @@ class TestExpressionPrettify(TestCase):
         cel = prettify(expr, ds)
         assert expected == cel
 
-    def test_square_bracket_subvariables(self):
+    def test_transitional_variable_url(self):
+        variable_url = 'https://host.com/api/datasets/123/variables/001/'
+        expr = {
+            'function': '==',
+            'args': [
+                {
+                    'variable': variable_url
+                },
+                {
+                    'value': 1
+                }
+            ]
+        }
+
+        ds = mock.MagicMock()
+        ds.__class__ = scrunch.mutable_dataset.MutableDataset
+        response = mock.MagicMock()
+        response.payload.body = {"alias": "age"}
+        response.payload.catalogs = {}
+        response.payload.fragments = {}
+        ds.resource.session.get.return_value = response
+
+        assert prettify(expr, ds) == 'age == 1'
+        ds.resource.session.get.assert_called_once_with(variable_url)
+
+    def test_var_square_bracket_subvariables(self):
         expr = {
             'function': '==',
             'args': [
@@ -3773,7 +3798,44 @@ class TestExpressionPrettify(TestCase):
         expected = 'array_alias[sv_1] == 1'
         assert prettify(expr, ds) == expected
 
-    def test_variable_url_no_dataset(self):
+    def test_transitional_variable_url_square_bracket_subvariables(self):
+        subvariable_url = 'https://host.com/api/datasets/123/variables/001/subvariables/abc/'
+        array_url = 'https://host.com/api/datasets/123/variables/001/'
+        expr = {
+            'function': '==',
+            'args': [
+                {
+                    'variable': subvariable_url
+                },
+                {
+                    'value': 1
+                }
+            ]
+        }
+
+        ds = mock.MagicMock()
+        ds.__class__ = scrunch.mutable_dataset.MutableDataset
+
+        subvar_resource = mock.MagicMock()
+        subvar_resource.catalogs = {"parent": "/subvariables/"}
+        subvar_resource.fragments = {"variable": array_url}
+        subvar_resource.body = {"alias": "sv_1"}
+
+        subvar_response = mock.MagicMock()
+        subvar_response.payload = subvar_resource
+
+        array_response = mock.MagicMock()
+        array_response.payload.body = {"alias": "array_alias"}
+
+        ds.resource.session.get.side_effect = [subvar_response, array_response]
+
+        assert prettify(expr, ds) == 'array_alias[sv_1] == 1'
+        assert ds.resource.session.get.call_args_list == [
+            mock.call(subvariable_url),
+            mock.call(array_url)
+        ]
+
+    def test_var_alias_no_dataset(self):
         expr = {
             'function': '==',
             'args': [
@@ -3787,6 +3849,27 @@ class TestExpressionPrettify(TestCase):
         }
 
         assert prettify(expr) == "var_alias == 1"
+
+    def test_transitional_variable_url_no_dataset(self):
+        expr = {
+            'function': '==',
+            'args': [
+                {
+                    'variable': 'https://host.com/api/datasets/123/variables/001/'
+                },
+                {
+                    'value': 1
+                }
+            ]
+        }
+
+        with pytest.raises(Exception) as err:
+            prettify(expr)
+
+        assert str(err.value) == (
+            'Valid Dataset instance is required to resolve variable urls '
+            'in the expression'
+        )
 
 
     def test_parse_equal_string(self):

--- a/scrunch/tests/test_recodes.py
+++ b/scrunch/tests/test_recodes.py
@@ -54,11 +54,11 @@ RESPONSE_NAMES = {
 RECODES_PAYLOAD = {
     'element': 'shoji:entity',
     'body': {
-        'alias': 'alias',
+        'alias': 'derived_variable_alias',
         'derivation': {
             'function': 'combine_categories',
             'args': [
-                {'variable': var_url},
+                {'var': 'dependency_variable_alias'},
                 {'value': [
                     {'combined_ids': [2, 3], 'missing': False, 'id': 1, 'name': 'China'},
                     {'combined_ids': [1], 'missing': False, 'id': 2, 'name': 'Other'}
@@ -151,14 +151,20 @@ class TestCombine(TestCase):
         resource = mock.MagicMock()
         resource.body = {'name': 'mocked_dataset'}
         entity_mock = mock.MagicMock()
-        entity_mock.entity.self = var_url
+        entity_mock.__getitem__.side_effect = lambda key: 'dependency_variable_alias' if key == 'alias' else None
         resource.variables.by.return_value = {
-            'test': entity_mock,
+            'dependency_variable_alias': entity_mock,
         }
         resource.variables.index = {}
         ds = MutableDataset(resource)
         with pytest.raises(ValueError) as err:
-            ds.combine_categorical('test', CATEGORY_MAP, CATEGORY_NAMES, name='name', alias='alias')
+            ds.combine_categorical(
+                'dependency_variable_alias',
+                CATEGORY_MAP,
+                CATEGORY_NAMES,
+                name='name',
+                alias='derived_variable_alias'
+            )
         ds.resource.variables.create.assert_called_with(RECODES_PAYLOAD)
         assert 'Entity mocked_dataset has no (sub)variable' in str(err.value)
 
@@ -168,18 +174,25 @@ class TestCombine(TestCase):
         entity_mock = mock.MagicMock()
         entity_mock.entity.self = var_url
         resource.variables.by.return_value = {
-            'test': entity_mock
+            'dependency_variable_alias': entity_mock
         }
         resource.variables.index = {}  # Var not present
 
         # mock a Tuple object
         tuple_mock = mock.MagicMock()
         tuple_mock.entity.self = var_url
+        tuple_mock.__getitem__.side_effect = lambda key: 'dependency_variable_alias' if key == 'alias' else None
 
         entity = Variable(tuple_mock, resource)
         ds = MutableDataset(resource)
         with pytest.raises(ValueError) as err:
-            ds.combine_categorical(entity, CATEGORY_MAP, CATEGORY_NAMES, name='name', alias='alias')
+            ds.combine_categorical(
+                entity,
+                CATEGORY_MAP,
+                CATEGORY_NAMES,
+                name='name',
+                alias='derived_variable_alias'
+            )
         ds.resource.variables.create.assert_called_with(RECODES_PAYLOAD)
         assert 'Entity mocked_dataset has no (sub)variable' in str(err.value)
 
@@ -368,13 +381,13 @@ class TestRecode(TestCase):
                     }, {
                         'function': 'in',
                         'args': [
-                            {'variable': 'http://test.crunch.io/api/datasets/123/variables/00001/'},
+                            {'var': 'sexuality'},
                             {'value': [1]}
                         ]
                     }, {
                         'function': 'in',
                         'args': [
-                            {'variable': 'http://test.crunch.io/api/datasets/123/variables/00001/'},
+                            {'var': 'sexuality'},
                             {'value': [2, 3, 4, 5]}
                         ]
                     }]

--- a/scrunch/tests/test_recodes.py
+++ b/scrunch/tests/test_recodes.py
@@ -79,7 +79,7 @@ COMBINE_RESPONSES_PAYLOAD = {
         'derivation': {
             'function': 'combine_responses',
             'args': [
-                {'variable': var_url},
+                {'var': 'test'},
                 {'value': [
                     {'alias': 'alias_1', 'combined_ids': [subvar1_url, subvar2_url], 'name': 'online'}
                 ]}

--- a/scrunch/variables.py
+++ b/scrunch/variables.py
@@ -56,6 +56,9 @@ def combinations_from_map(map, categories, missing):
     return combinations
 
 
+# NOTE: This needs to stay the same because the translation
+# to zz9 is done on cr.lib level, and that's where we need
+# to convert variables from urls to aliases
 def combine_responses_expr(variable_url, responses):
     return {
         'function': 'combine_responses',
@@ -67,11 +70,11 @@ def combine_responses_expr(variable_url, responses):
     }
 
 
-def combine_categories_expr(variable_url, combinations):
+def combine_categories_expr(var_alias, combinations):
     return {
         'function': 'combine_categories',
         'args': [{
-            'variable': variable_url
+            'var': var_alias
         }, {
             'value': combinations
         }]

--- a/scrunch/variables.py
+++ b/scrunch/variables.py
@@ -56,14 +56,11 @@ def combinations_from_map(map, categories, missing):
     return combinations
 
 
-# NOTE: This needs to stay the same because the translation
-# to zz9 is done on cr.lib level, and that's where we need
-# to convert variables from urls to aliases
-def combine_responses_expr(variable_url, responses):
+def combine_responses_expr(var_alias, responses):
     return {
         'function': 'combine_responses',
         'args': [{
-            'variable': variable_url
+            'var': var_alias
         }, {
             'value': responses
         }]

--- a/scrunch/version.py
+++ b/scrunch/version.py
@@ -10,4 +10,4 @@ try:
     __version__ = version('scrunch')
 except Exception:
     # Package is installed from source. It's at least this version
-    __version__ = "0.18.21-uninstalled"
+    __version__ = "0.18.22-uninstalled"


### PR DESCRIPTION
All derivation expressions should use `{"var": <alias>}` syntax. The `{"variable": <varid>}` syntax is deprecated and will not be supported in the fututre.