### PR TITLE
ZC-3836 Send combine_logical_responses from scrunch

### DIFF
--- a/scrunch/datasets.py
+++ b/scrunch/datasets.py
@@ -37,8 +37,7 @@ from scrunch.helpers import (ReadOnly, _validate_category_rules, abs_url,
                              generate_subvariable_codes, shoji_order_wrapper)
 from scrunch.order import DatasetVariablesOrder
 from scrunch.subentity import Deck, Filter, Multitable
-from scrunch.variables import (combinations_from_map, combine_categories_expr,
-                               combine_responses_expr, responses_from_map)
+from scrunch.variables import combinations_from_map, combine_categories_expr
 
 from scrunch.connections import LOG, _default_connection, _get_connection
 
@@ -1900,14 +1899,58 @@ class BaseDataset(ReadOnly, DatasetVariablesMixin):
             parent_alias = variable.alias
 
         # TODO: Implement `default` parameter in Crunch API
-        responses = responses_from_map(variable, map, categories or {}, alias,
-                                       parent_alias)
+        categories = categories or {}
+        subvars = variable.resource.subvariables.by('alias')
+
+        # In python 2.7, range(...) returns a list, starting from python 3,
+        # range is a python type.
+        if six.PY2:
+            supported_iterable_types = (list, tuple)
+        else:
+            supported_iterable_types = (list, tuple, range)
+
+        def as_list(value):
+            return value if isinstance(value, supported_iterable_types) else [value]
+
+        try:
+            value = []
+            subreferences = []
+            for response_id, mapped_response_ids in sorted(six.iteritems(map)):
+                output_alias = subvar_alias(alias, response_id)
+                mapped_codes = [
+                    subvar_alias(parent_alias, sv_alias)
+                    for sv_alias in as_list(mapped_response_ids)
+                ]
+                for mapped_code in mapped_codes:
+                    subvars[mapped_code]
+
+                value.append({
+                    'code': output_alias,
+                    'mapped codes': mapped_codes,
+                })
+                subreferences.append({
+                    'alias': output_alias,
+                    'name': categories.get(response_id, "Response %s" % response_id),
+                })
+        except KeyError:
+            # This means we tried to combine a subvariable with ~id~ that does not
+            # exist in the subvariables. Treat as bad input.
+            raise ValueError("Unknown subvariables for variable %s" % parent_alias)
+
         payload = shoji_entity_wrapper({
             'name': name,
             'alias': alias,
             'description': description,
-            'derivation': combine_responses_expr(
-                parent_alias, responses)
+            'derivation': {
+                'function': 'combine_logical_responses',
+                'args': [
+                    {'var': parent_alias},
+                    {'value': value}
+                ],
+                'references': {
+                    'subreferences': subreferences
+                }
+            }
         })
         return self._var_create_reload_return(payload)
 

--- a/scrunch/tests/test_recodes.py
+++ b/scrunch/tests/test_recodes.py
@@ -4,7 +4,6 @@ from unittest import TestCase
 import pytest
 from scrunch.datasets import Variable
 from scrunch.mutable_dataset import MutableDataset
-from scrunch.variables import responses_from_map
 from scrunch.helpers import subvar_alias
 
 from pycrunch.shoji import Entity
@@ -70,20 +69,25 @@ RECODES_PAYLOAD = {
     }
 }
 
-COMBINE_RESPONSES_PAYLOAD = {
+COMBINE_LOGICAL_RESPONSES_PAYLOAD = {
     'element': 'shoji:entity',
     'body': {
         'name': 'name',
         'description': '',
         'alias': 'alias',
         'derivation': {
-            'function': 'combine_responses',
+            'function': 'combine_logical_responses',
             'args': [
                 {'var': 'test'},
                 {'value': [
-                    {'alias': 'alias_1', 'combined_ids': [subvar1_url, subvar2_url], 'name': 'online'}
+                    {'code': 'alias_1', 'mapped codes': ['test_1', 'test_2']}
                 ]}
-            ]
+            ],
+            'references': {
+                'subreferences': [
+                    {'alias': 'alias_1', 'name': 'online'}
+                ]
+            }
         }
     }
 }
@@ -91,47 +95,93 @@ COMBINE_RESPONSES_PAYLOAD = {
 
 class TestCombine(TestCase):
 
-    def test_validate_range_expression(self):
-        test_map = {
-            1: range(1, 5)
-        }
-        test_cats = {
-            1: "China"
-        }
-        ds_res_mock = mock.MagicMock()
-        variable_mock = mock.MagicMock()
+    def test_combine_responses_range_mapping_by_alias(self):
+        resource = mock.MagicMock()
+        resource.body = {'name': 'mocked_dataset'}
+        resource.entity.self = dataset_url
+        resource.variables.index = {}
         subvar_mock = mock.MagicMock(entity_url=subvar1_url)
-        # mock the call to entity, this will happen on Variable.resource
-        variable_mock.entity.subvariables.by.return_value = {
-            'parent_1': subvar_mock,
-            'parent_2': subvar_mock,
-            'parent_3': subvar_mock,
-            'parent_4': subvar_mock,
-        }
-        parent_var = Variable(variable_mock, ds_res_mock)
-        modified_map = responses_from_map(parent_var, test_map, test_cats, 'test', 'parent')
-        # subvar_url * 4 because we used the same mock for all subvars
-        assert modified_map[0]['combined_ids'] == [subvar1_url] * 4
 
-    def test_validate_integer(self):
-        test_map = {
-            1: 1
+        entity_mock = mock.MagicMock()
+        entity_mock.entity.self = var_url
+        entity_mock.entity.subvariables.by.return_value = {
+            'test_1': subvar_mock,
+            'test_2': subvar_mock,
+            'test_3': subvar_mock,
+            'test_4': subvar_mock,
         }
-        test_cats = {
-            1: "China"
-        }
+        resource.variables.by.return_value = {'test': entity_mock}
 
-        ds_res_mock = mock.MagicMock()
-        variable_mock = mock.MagicMock()
-        subvar_mock = mock.MagicMock(entity_url=subvar1_url)
-        # mock the call to entity, this will happen on Variable.resource
-        variable_mock.entity.subvariables.by.return_value = {
-            'parent_1': subvar_mock
+        ds = MutableDataset(resource)
+        with pytest.raises(ValueError):
+            ds.combine_multiple_response(
+                'test', {1: range(1, 5)}, {1: 'China'}, name='name', alias='alias'
+            )
+
+        resource.variables.create.assert_called_with({
+            'element': 'shoji:entity',
+            'body': {
+                'name': 'name',
+                'description': '',
+                'alias': 'alias',
+                'derivation': {
+                    'function': 'combine_logical_responses',
+                    'args': [
+                        {'var': 'test'},
+                        {'value': [
+                            {'code': 'alias_1', 'mapped codes': ['test_1', 'test_2', 'test_3', 'test_4']}
+                        ]}
+                    ],
+                    'references': {
+                        'subreferences': [
+                            {'alias': 'alias_1', 'name': 'China'}
+                        ]
+                    }
+                }
+            }
+        })
+
+    def test_combine_responses_scalar_mapping_by_alias(self):
+        resource = mock.MagicMock()
+        resource.body = {'name': 'mocked_dataset'}
+        resource.entity.self = dataset_url
+        resource.variables.index = {}
+
+        entity_mock = mock.MagicMock()
+        entity_mock.entity.self = var_url
+        entity_mock.entity.subvariables.by.return_value = {
+            'test_1': mock.MagicMock(entity_url=subvar1_url)
         }
-        parent_var = Variable(variable_mock, ds_res_mock)
-        modified_map = responses_from_map(parent_var, test_map, test_cats, 'test', 'parent')
-        # subvar_url * 4 because we used the same mock for all subvars
-        assert modified_map[0]['combined_ids'] == [subvar1_url]
+        resource.variables.by.return_value = {'test': entity_mock}
+
+        ds = MutableDataset(resource)
+        with pytest.raises(ValueError):
+            ds.combine_multiple_response(
+                'test', {1: 1}, {1: 'China'}, name='name', alias='alias'
+            )
+
+        resource.variables.create.assert_called_with({
+            'element': 'shoji:entity',
+            'body': {
+                'name': 'name',
+                'description': '',
+                'alias': 'alias',
+                'derivation': {
+                    'function': 'combine_logical_responses',
+                    'args': [
+                        {'var': 'test'},
+                        {'value': [
+                            {'code': 'alias_1', 'mapped codes': ['test_1']}
+                        ]}
+                    ],
+                    'references': {
+                        'subreferences': [
+                            {'alias': 'alias_1', 'name': 'China'}
+                        ]
+                    }
+                }
+            }
+        })
 
     def test_combine_categories_unknown_alias(self):
         resource = mock.MagicMock()
@@ -253,7 +303,7 @@ class TestCombine(TestCase):
         ds = MutableDataset(resource)
         with pytest.raises(ValueError) as err:
             ds.combine_multiple_response('test', RESPONSE_MAP, RESPONSE_NAMES, name='name', alias='alias')
-        resource.variables.create.assert_called_with(COMBINE_RESPONSES_PAYLOAD)
+        resource.variables.create.assert_called_with(COMBINE_LOGICAL_RESPONSES_PAYLOAD)
         assert 'Entity mocked_dataset has no (sub)variable' in str(err.value)
 
     def test_combine_responses_by_entity(self):
@@ -287,7 +337,7 @@ class TestCombine(TestCase):
 
         with pytest.raises(ValueError) as err:
             ds.combine_multiple_response(entity_mock, RESPONSE_MAP, RESPONSE_NAMES, name='name', alias='alias')
-        resource.variables.create.assert_called_with(COMBINE_RESPONSES_PAYLOAD)
+        resource.variables.create.assert_called_with(COMBINE_LOGICAL_RESPONSES_PAYLOAD)
         assert 'Entity mocked_dataset has no (sub)variable' in str(err.value)
 
 

--- a/scrunch/variables.py
+++ b/scrunch/variables.py
@@ -2,8 +2,6 @@ import re
 
 import six
 
-from scrunch.helpers import subvar_alias
-
 VARIABLE_URL_REGEX = re.compile(
     r"^(http|https):\/\/(.*)\/api\/datasets\/([\w\d]+)\/variables\/([\w\d]+)"
     r"(\/subvariables\/([\w\d]*))?\/?$"
@@ -17,34 +15,6 @@ def validate_variable_url(url):
     return VARIABLE_URL_REGEX.match(url)
 
 
-def responses_from_map(variable, response_map, cat_names, alias, parent_alias):
-    subvars = variable.resource.subvariables.by('alias')
-
-    # In python 2.7, range(...) returns a list, starting from python 3,
-    # range is a python type
-    if six.PY2:
-        _supported_iterable_types = (list, tuple)
-    else:
-        _supported_iterable_types = (list, tuple, range)
-
-    try:
-        responses = [
-            {
-                'name': cat_names.get(response_id, "Response %s" % response_id),
-                'alias': subvar_alias(alias, response_id),
-                'combined_ids': [
-                    subvars[subvar_alias(parent_alias, sv_alias)].entity_url
-                    for sv_alias in (combined_ids if isinstance(combined_ids, _supported_iterable_types) else [combined_ids])
-                ]
-            } for response_id, combined_ids in sorted(six.iteritems(response_map))
-        ]
-    except KeyError:
-        # This means we tried to combine a subvariable with ~id~ that does not
-        # exist in the subvariables. Treat as bad input.
-        raise ValueError("Unknown subvariables for variable %s" % parent_alias)
-    return responses
-
-
 def combinations_from_map(map, categories, missing):
     missing = missing if isinstance(missing, list) else [missing]
     combinations = [{
@@ -54,17 +24,6 @@ def combinations_from_map(map, categories, missing):
         'combined_ids': combined_ids if isinstance(combined_ids, (list, tuple)) else [combined_ids]
     } for cat_id, combined_ids in sorted(six.iteritems(map))]
     return combinations
-
-
-def combine_responses_expr(var_alias, responses):
-    return {
-        'function': 'combine_responses',
-        'args': [{
-            'var': var_alias
-        }, {
-            'value': responses
-        }]
-    }
 
 
 def combine_categories_expr(var_alias, combinations):


### PR DESCRIPTION
## Summary
- update multiple-response combine derivations to send `combine_logical_responses` directly
- keep the existing scrunch `combine_multiple_response()` public API unchanged
- cover alias and entity input paths with unit payload assertions

Jira: https://crunchio.atlassian.net/browse/ZC-3836

## Tests
- `venv/bin/python -m pytest scrunch/tests -q`