### PR TITLE
Fix multiple response filters without entity metadata

### DIFF
--- a/scrunch/expressions.py
+++ b/scrunch/expressions.py
@@ -490,19 +490,19 @@ def get_dataset_variables(ds):
 
 
 def get_subvariables_resource(var_url, var_index):
-    variable = var_index[var_url].entity
-    sub_variables = variable.subvariables['index']
-    return {sv['alias'].strip('#'): sv['id'] for sv in sub_variables.values()}
-
-
-def _get_categories_from_var_index(vars_by_alias, var_alias):
-    return vars_by_alias[var_alias].entity.body.categories
+    """Return subvariable alias -> id from table metadata subreferences."""
+    subreferences = var_index[var_url].get("subreferences", {}) or {}
+    return {
+        subref["alias"].strip('#'): subvar_id
+        for subvar_id, subref in subreferences.items()
+    }
 
 
 def adapt_multiple_response(var_alias, values, vars_by_alias):
     """
-    Converts multiple response arguments
-    to column.
+    Convert multiple response arguments to the API's per-subvariable column form.
+
+    vars_by_alias is the table-derived alias map from get_dataset_variables().
     :return: the new args for multiple_response
     """
     aliases = get_subvariables_resource(var_alias, vars_by_alias)
@@ -516,7 +516,7 @@ def adapt_multiple_response(var_alias, values, vars_by_alias):
         # scenario var.any([subvar1, subvar2])
         # in this scenario, we only want category ids that refers to `selected` categories
         column = [
-            cat.get("id") for cat in _get_categories_from_var_index(vars_by_alias, var_alias) if cat.get("selected")
+            cat.get("id") for cat in vars_by_alias[var_alias].get("categories", []) if cat.get("selected")
         ]
         subvars = [sva for sva in values if sva in aliases]
 
@@ -534,6 +534,7 @@ def _update_values_for_multiple_response(new_values, values, subitem, vars_by_al
     """
     - Multiple response does not need the `value` key, but it relies on the `column` key
     - Remove from `arrays` (subvariable list) the ones that should not be considered
+    - vars_by_alias is the table-derived alias map from get_dataset_variables()
     """
     var_alias = subitem.get("var")
     column = new_values[0].get("column")
@@ -544,7 +545,7 @@ def _update_values_for_multiple_response(new_values, values, subitem, vars_by_al
         elif value is not None:
             values[0]['column'] = value
         values[0].pop("value", None)
-        subvar_ids_by_aliases = {v['alias']: k for k, v in vars_by_alias[var_alias]['entity']['subvariables']['index'].items()}
+        subvar_ids_by_aliases = get_subvariables_resource(var_alias, vars_by_alias)
         arrays[0] = [subvar_ids_by_aliases[new_value["axes"][0]] for new_value in new_values]
 
 
@@ -575,7 +576,6 @@ def process_expr(obj, ds):
     """
 
     variables = get_dataset_variables(ds)
-    var_index = ds.variables.index
 
     def ensure_category_ids(subitems, values, arrays, variables=variables):
         """Replace category-name strings in value args with their numeric
@@ -624,18 +624,21 @@ def process_expr(obj, ds):
                 return var_value
             return value
 
-        # MR special case: when the args look like (<var>, <value>) and the
-        # variable is multiple_response, delegate to the MR adapter which
-        # rewrites the filter into the array-level `column` form.
+        # MR special case: use the table-derived variables map, not
+        # ds.variables.index, because variables.index may only contain sparse
+        # subvariable URLs without the aliases needed for expansion.
         if len(subitems) == 2:
             _variable, _value = subitems
             var_alias = _variable.get('var')
             _value_key = next(iter(_value))
             if _value_key in {'column', "value"} and var_alias:
-                vars_by_alias = {v['alias']: v for _, v in var_index.items()}
-                if var_alias in vars_by_alias and vars_by_alias[var_alias]['type'] == 'multiple_response':
-                    result = adapt_multiple_response(var_alias, _value[_value_key], vars_by_alias)
-                    _update_values_for_multiple_response(result[0], values, subitems[0], vars_by_alias, arrays)
+                if (
+                    var_alias in variables
+                    and variables[var_alias]['type'] == 'multiple_response'
+                    and isinstance(_value[_value_key], (list, tuple))
+                ):
+                    result = adapt_multiple_response(var_alias, _value[_value_key], variables)
+                    _update_values_for_multiple_response(result[0], values, subitems[0], variables, arrays)
                     return result
 
         # General case: replace category names with their ids inside each

--- a/scrunch/tests/test_expressions.py
+++ b/scrunch/tests/test_expressions.py
@@ -1670,8 +1670,12 @@ class TestExpressionProcessing(TestCase):
             {"id": 3, "name": "cat3", "selected": False},
         ]
 
-        table_mock = mock.MagicMock(metadata={
-            var_id: {
+        # adapt_multiple_response receives the alias map built by
+        # get_dataset_variables() from table metadata, not ds.variables.index.
+        # The table metadata has the subreference aliases needed for the MR
+        # expansion; variables.index may only have sparse subvariable URLs.
+        table_variables_by_alias = {
+            var_alias: {
                 'id': var_id,
                 'alias': var_alias,
                 'type': var_type,
@@ -1687,63 +1691,31 @@ class TestExpressionProcessing(TestCase):
                 },
                 "categories": var_categories
             }
-        })
-        ds = mock.MagicMock()
-        ds.self = self.ds_url
-        ds.variables.index = {
-            "{}".format(var_url): {
-                "name": "Multiple Response",
-                "description": "",
-                "notes": "",
-                "alias": var_alias,
-                "id": "{}".format(var_id),
-                "type": "multiple_response",
-                "subvariables": [
-                    "{}subvariables/001/".format(var_url),
-                    "{}subvariables/002/".format(var_url),
-                    "{}subvariables/003/".format(var_url),
-                ],
-            }
         }
-
-        ds.follow.return_value = table_mock
         values = ["subvar1", "subvar2"]
-        with mock.patch("scrunch.expressions.get_subvariables_resource") as mock_subvars, mock.patch("scrunch.expressions._get_categories_from_var_index") as categories:
-            categories.return_value = var_categories
-            mock_subvars.return_value = dict(sorted({"subvar1": "001", "subvar2": "002", "subvar3": "003"}.items()))
-            vars_by_alias = {v['alias']: v for _, v in ds.variables.index.items()}
-            result, need_wrap = adapt_multiple_response(var_alias, values, vars_by_alias)
-            assert result == [
-                {'var': var_alias, 'axes': ['subvar1'], 'column': [1, 2]},
-                {'var': var_alias, 'axes': ['subvar2'], 'column': [1, 2]}
-            ]
-            assert need_wrap is True
+        result, need_wrap = adapt_multiple_response(var_alias, values, table_variables_by_alias)
+        assert result == [
+            {'var': var_alias, 'axes': ['subvar1'], 'column': [1, 2]},
+            {'var': var_alias, 'axes': ['subvar2'], 'column': [1, 2]}
+        ]
+        assert need_wrap is True
 
     def test_adapt_multiple_response_any_category_id(self):
         var_alias = 'MyMrVar'
-        vars_by_alias = {
+        # Same table-derived alias map shape used by process_expr().
+        table_variables_by_alias = {
             var_alias: {
                 "alias": var_alias,
                 "type": "multiple_response",
-                "entity": {
-                    "subvariables": {
-                        "index": {
-                            "001": {"id": "001", "alias": "subvar1"},
-                            "002": {"id": "002", "alias": "subvar2"},
-                            "003": {"id": "003", "alias": "subvar3"},
-                        }
-                    }
+                "subreferences": {
+                    "001": {"alias": "subvar1"},
+                    "002": {"alias": "subvar2"},
+                    "003": {"alias": "subvar3"},
                 }
             }
         }
 
-        with mock.patch("scrunch.expressions.get_subvariables_resource") as mock_subvars:
-            mock_subvars.return_value = {
-                "subvar1": "001",
-                "subvar2": "002",
-                "subvar3": "003",
-            }
-            result, need_wrap = adapt_multiple_response(var_alias, [1], vars_by_alias)
+        result, need_wrap = adapt_multiple_response(var_alias, [1], table_variables_by_alias)
 
         assert result == [
             {'var': var_alias, 'axes': ['subvar1'], 'column': [1]},
@@ -1810,9 +1782,7 @@ class TestExpressionProcessing(TestCase):
 
         ds.follow.return_value = table_mock
         expr = "MyMrVar.all([1])"
-        with mock.patch("scrunch.expressions.get_subvariables_resource") as mock_subvars, mock.patch(
-                "scrunch.expressions._get_categories_from_var_index") as categories:
-            categories.return_value = var_categories
+        with mock.patch("scrunch.expressions.get_subvariables_resource") as mock_subvars:
             mock_subvars.return_value = dict(sorted({"subvar1": "001", "subvar2": "002", "subvar3": "003"}.items()))
             parsed_expr = parse_expr(expr)
             processed_zcl_expr = process_expr(parsed_expr, ds)
@@ -1901,9 +1871,7 @@ class TestExpressionProcessing(TestCase):
 
         ds.follow.return_value = table_mock
         expr = "MyMrVar in [1]"
-        with mock.patch("scrunch.expressions.get_subvariables_resource") as mock_subvars, mock.patch(
-                "scrunch.expressions._get_categories_from_var_index") as categories:
-            categories.return_value = var_categories
+        with mock.patch("scrunch.expressions.get_subvariables_resource") as mock_subvars:
             mock_subvars.return_value = dict(sorted({"subvar1": "001", "subvar2": "002", "subvar3": "003"}.items()))
             parsed_expr = parse_expr(expr)
             processed_zcl_expr = process_expr(parsed_expr, ds)
@@ -1933,6 +1901,63 @@ class TestExpressionProcessing(TestCase):
                     }
                 ],
             }
+
+    def test_process_in_multiple_response_without_entity_key(self):
+        var_id = '0001'
+        var_alias = 'MyMrVar'
+        var_type = 'multiple_response'
+        var_categories = [
+            {"id": 1, "name": "cat1", "selected": True},
+            {"id": 2, "name": "cat2", "selected": True},
+            {"id": 3, "name": "cat3", "selected": False},
+        ]
+
+        table_mock = mock.MagicMock(metadata={
+            var_id: {
+                'id': var_id,
+                'alias': var_alias,
+                'type': var_type,
+                "subvariables": ["001", "002", "003"],
+                "subreferences": {
+                    "001": {"alias": "subvar1"},
+                    "002": {"alias": "subvar2"},
+                    "003": {"alias": "subvar3"},
+                },
+                "categories": var_categories
+            }
+        })
+        ds = mock.MagicMock()
+        ds.self = self.ds_url
+
+        ds.follow.return_value = table_mock
+        parsed_expr = parse_expr("MyMrVar in [1]")
+
+        assert process_expr(parsed_expr, ds) == {
+            'function': 'or',
+            'args': [
+                {
+                    'function': 'in',
+                    'args': [
+                        {'var': var_alias, 'axes': ['subvar1']},
+                        {'column': [1]}
+                    ],
+                },
+                {
+                    'function': 'in',
+                    'args': [
+                        {'var': var_alias, 'axes': ['subvar2']},
+                        {'column': [1]}
+                    ],
+                },
+                {
+                    'function': 'in',
+                    'args': [
+                        {'var': var_alias, 'axes': ['subvar3']},
+                        {'column': [1]}
+                    ],
+                }
+            ],
+        }
 
     def test_multiple_response_any_process_single_subvariables(self):
         var_id = '0001'
@@ -2001,9 +2026,7 @@ class TestExpressionProcessing(TestCase):
         ds.follow.return_value = table_mock
         expr = "MyMrVar.any([subvar1])"
         parsed_expr = parse_expr(expr)
-        with mock.patch("scrunch.expressions.get_subvariables_resource") as mock_subvars, mock.patch(
-                "scrunch.expressions._get_categories_from_var_index") as categories:
-            categories.return_value = var_categories
+        with mock.patch("scrunch.expressions.get_subvariables_resource") as mock_subvars:
             mock_subvars.return_value = dict(sorted({"subvar1": "001", "subvar2": "002", "subvar3": "003"}.items()))
             processed_zcl_expr = process_expr(parsed_expr, ds)
         assert processed_zcl_expr == {
@@ -2087,8 +2110,7 @@ class TestExpressionProcessing(TestCase):
         ds.follow.return_value = table_mock
         expr = "MyMrVar.any([subvar1, subvar2])"
         parsed_expr = parse_expr(expr)
-        with mock.patch("scrunch.expressions.get_subvariables_resource") as mock_subvars, mock.patch("scrunch.expressions._get_categories_from_var_index") as categories:
-            categories.return_value = var_categories
+        with mock.patch("scrunch.expressions.get_subvariables_resource") as mock_subvars:
             mock_subvars.return_value = dict(sorted({"subvar1": "001", "subvar2": "002", "subvar3": "003"}.items()))
             processed_zcl_expr = process_expr(parsed_expr, ds)
         assert processed_zcl_expr == {


### PR DESCRIPTION
## Summary
- support multiple-response variable metadata that is exposed without an entity key
- use table-derived metadata for multiple-response expansion so sparse variables.index metadata still works
- keep scalar subvariable equality untouched while expanding list-style MR filters
- add a regression test for the add_filter-style metadata shape from #503