### PR TITLE
Fix MR subvariable in filters

### DIFF
--- a/scrunch/expressions.py
+++ b/scrunch/expressions.py
@@ -636,6 +636,7 @@ def process_expr(obj, ds):
                     var_alias in variables
                     and variables[var_alias]['type'] == 'multiple_response'
                     and isinstance(_value[_value_key], (list, tuple))
+                    and 'axes' not in _variable
                 ):
                     result = adapt_multiple_response(var_alias, _value[_value_key], variables)
                     _update_values_for_multiple_response(result[0], values, subitems[0], variables, arrays)

--- a/scrunch/tests/test_expressions.py
+++ b/scrunch/tests/test_expressions.py
@@ -1606,7 +1606,7 @@ class TestExpressionParsing(TestCase):
 #     'index_mapper': {'pets_sample': not_any([1, 2, 3, 4])}}]
 
 
-class TestExpressionProcessing(TestCase):
+class TestExpressionProcessing:
 
     ds_url = 'http://test.crunch.io/api/datasets/123/'
 
@@ -2143,7 +2143,12 @@ class TestExpressionProcessing(TestCase):
             ]
         }
 
-    def test_multiple_response_subvar_equality(self):
+    @pytest.mark.parametrize("expr, function, expected_value", [
+        ('subvar1 == 1', '==', {'value': 1}),
+        ('subvar1 in [1]', 'in', {'value': [1]}),
+        ('MyMrVar[subvar1] in [1]', 'in', {'value': [1]}),
+    ])
+    def test_multiple_response_subvar_filter(self, expr, function, expected_value):
         var_id = '0001'
         var_alias = 'MyMrVar'
         var_type = 'multiple_response'
@@ -2208,20 +2213,15 @@ class TestExpressionProcessing(TestCase):
             }
         }
         ds.follow.return_value = table_mock
-        expr = 'subvar1 == 1'
-        parsed_expr = parse_expr(expr)
-        expr_obj = process_expr(parsed_expr, ds)
 
-        assert expr_obj == {
-            'function': '==',
+        assert process_expr(parse_expr(expr), ds) == {
+            'function': function,
             'args': [
                 {
                     'var': var_alias,
                     'axes': ['subvar1']
                 },
-                {
-                    'value': 1
-                }
+                expected_value
             ]
         }
 


### PR DESCRIPTION
## Summary
- avoid whole-MR expansion when an expression is already scoped to a subvariable via axes
- add regression coverage for both `subvar1 in [1]` and `MyMrVar[subvar1] in [1]`

## Diagnosis
The 0.18.24 MR rewrite treats list-valued filters on MR variables as whole-variable filters that need expansion across all subvariables. If the variable term has already been rewritten to `{var: parent, axes: [subvar]}`, there is no array list to update, so `_update_values_for_multiple_response()` crashes on `arrays[0]` with `IndexError: list assignment index out of range`.

## Tests
- venv/bin/python -m pytest scrunch/tests/test_expressions.py::TestExpressionProcessing::test_multiple_response_subvar_in scrunch/tests/test_expressions.py::TestExpressionProcessing::test_multiple_response_subvar_equality scrunch/tests/test_expressions.py::TestExpressionProcessing::test_process_in_multiple_response_without_entity_key scrunch/tests/test_expressions.py::TestExpressionProcessing::test_process_in_multiple_response scrunch/tests/test_expressions.py::TestExpressionProcessing::test_process_all_multiple_response scrunch/tests/test_expressions.py::TestExpressionProcessing::test_multiple_response_any_process_single_subvariables scrunch/tests/test_expressions.py::TestExpressionProcessing::test_multiple_response_any_process_two_subvariables -q
- venv/bin/python -m pytest scrunch/tests -q
